### PR TITLE
fix: enable edge-to-edge display for Android 15+ compatibility

### DIFF
--- a/android/app/src/main/java/com/eStundnzettl/app/MainActivity.java
+++ b/android/app/src/main/java/com/eStundnzettl/app/MainActivity.java
@@ -1,7 +1,9 @@
 package com.estundnzettl.app;
 
 import android.content.Intent;
+import android.os.Bundle;
 import android.util.Log;
+import androidx.activity.EdgeToEdge;
 import com.getcapacitor.BridgeActivity;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginHandle;
@@ -9,7 +11,14 @@ import ee.forgr.capacitor.social.login.GoogleProvider;
 import ee.forgr.capacitor.social.login.ModifiedMainActivityForSocialLoginPlugin;
 
 public class MainActivity extends BridgeActivity implements ModifiedMainActivityForSocialLoginPlugin {
-    
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        // Enable edge-to-edge display for Android 15+ compatibility
+        EdgeToEdge.enable(this);
+    }
+
     @Override
     public void IHaveModifiedTheMainActivityForTheUseWithSocialLoginPlugin() {
         // Required by the interface - intentionally empty

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -16,7 +16,6 @@
 
     <style name="AppTheme.NoActionBarLaunch" parent="AppTheme.NoActionBar">
         <item name="android:windowBackground">#020617</item>
-        <item name="android:statusBarColor">#020617</item> 
     </style>
 
 </resources>


### PR DESCRIPTION
## Summary
Fix Play Console warnings regarding Android 15+ edge-to-edge display compatibility.

## Changes
1. **styles.xml**: Removed deprecated `android:statusBarColor` from `AppTheme.NoActionBarLaunch` — this attribute conflicts with edge-to-edge mode
2. **MainActivity.java**: Added `EdgeToEdge.enable(this)` call in `onCreate()` to properly enable edge-to-edge display with backward compatibility

## Why
- Starting with Android 15 (API 35), apps targeting SDK 35+ are displayed edge-to-edge by default
- Apps should call `EdgeToEdge.enable()` to ensure proper handling and backward compatibility with Android 10-14
- The deprecated `setStatusBarColor()` / `getStatusBarColor()` APIs in the android-browser-helper library will auto-fix when that library updates

## Testing
- Build passed: `./gradlew assembleDebug` ✓
- No other files modified