### PR TITLE
feat(archive): Automatisches monatliches PDF-Archiv (Lokal + Nextcloud)

### DIFF
--- a/android/app/src/main/java/com/eStundnzettl/app/NextcloudLoginFlowPlugin.java
+++ b/android/app/src/main/java/com/eStundnzettl/app/NextcloudLoginFlowPlugin.java
@@ -100,6 +100,7 @@ public class NextcloudLoginFlowPlugin extends Plugin {
         String urlStr = call.getString("url");
         String method = call.getString("method", "GET");
         String body = call.getString("body");
+        String bodyBase64 = call.getString("bodyBase64");
         String username = call.getString("username");
         String password = call.getString("password");
         String reqContentType = call.getString("contentType");
@@ -160,6 +161,13 @@ public class NextcloudLoginFlowPlugin extends Plugin {
                 } else if ("PROPFIND".equals(upperMethod)) {
                     // PROPFIND with empty body
                     requestBody = RequestBody.create(new byte[0], null);
+                } else if (bodyBase64 != null) {
+                    // PUT, POST, etc. with binary body (base64-encoded)
+                    MediaType mediaType = reqContentType != null
+                        ? MediaType.parse(reqContentType)
+                        : null;
+                    byte[] rawBytes = android.util.Base64.decode(bodyBase64, android.util.Base64.DEFAULT);
+                    requestBody = RequestBody.create(rawBytes, mediaType);
                 } else if (body != null) {
                     // PUT, POST, etc. with actual body
                     MediaType mediaType = reqContentType != null

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eStundnzettl",
-  "version": "3.1.1",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eStundnzettl",
-      "version": "3.1.1",
+      "version": "3.2.1",
       "hasInstallScript": true,
       "dependencies": {
         "@capacitor-community/date-picker": "^7.1.0",
@@ -28,6 +28,7 @@
         "html2pdf.js": "^0.14.0",
         "i18next": "^26.0.3",
         "lucide-react": "^1.7.0",
+        "pdfmake": "^0.3.7",
         "react": "^19.2.4",
         "react-datepicker": "^9.1.0",
         "react-dom": "^19.2.4",
@@ -1689,6 +1690,30 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2230,6 +2255,15 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
@@ -3215,7 +3249,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3297,6 +3330,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
       }
     },
     "node_modules/browser-fs-access": {
@@ -3492,6 +3534,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/clsx": {
@@ -3783,6 +3834,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -4391,7 +4448,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -4556,6 +4612,23 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -5722,6 +5795,12 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/js-md5": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6230,6 +6309,25 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/localforage": {
@@ -6864,6 +6962,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pdfkit": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.18.0.tgz",
+      "integrity": "sha512-NvUwSDZ0eYEzqAiWwVQkRkjYUkZ48kcsHuCO31ykqPPIVkwoSDjDGiwIgHHNtsiwls3z3P/zy4q00hl2chg2Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^1.0.0",
+        "@noble/hashes": "^1.6.0",
+        "fontkit": "^2.0.4",
+        "js-md5": "^0.8.3",
+        "linebreak": "^1.1.0",
+        "png-js": "^1.0.0"
+      }
+    },
+    "node_modules/pdfmake": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/pdfmake/-/pdfmake-0.3.7.tgz",
+      "integrity": "sha512-SwTFcaH3kCJBlPFWi/YB34zRg6lpCxq90tkZ9GxfSi9/v4Tk96cv4IvOstA+CC40rdW1OzQIuNhD2DLD1RDVgA==",
+      "license": "MIT",
+      "dependencies": {
+        "linebreak": "^1.1.0",
+        "pdfkit": "^0.18.0",
+        "xmldoc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -6912,6 +7038,11 @@
       "engines": {
         "node": ">=10.4.0"
       }
+    },
+    "node_modules/png-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
+      "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
@@ -7329,6 +7460,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -8134,6 +8271,12 @@
         "readable-stream": "3"
       }
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -8378,6 +8521,32 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -8919,6 +9088,27 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xmldoc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-2.0.3.tgz",
+      "integrity": "sha512-6gRk4NY/Jvg67xn7OzJuxLRsGgiXBaPUQplVJ/9l99uIugxh4FTOewYz5ic8WScj7Xx/2WvhENiQKwkK9RpE4w==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.4.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/xmldoc/node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "html2pdf.js": "^0.14.0",
     "i18next": "^26.0.3",
     "lucide-react": "^1.7.0",
+    "pdfmake": "^0.3.7",
     "react": "^19.2.4",
     "react-datepicker": "^9.1.0",
     "react-dom": "^19.2.4",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,7 @@ import LiveTimerOverlay from "./components/LiveTimerOverlay";
 import { useEntries } from "./hooks/useEntries";
 import { useSettings } from "./hooks/useSettings";
 import { useAutoBackup } from "./hooks/useAutoBackup";
+import { useAutoPdfArchive } from "./hooks/useAutoPdfArchive";
 import { useLiveTimer } from "./hooks/useLiveTimer";
 import { useExport } from "./hooks/useExport";
 import { useFormState } from "./hooks/useFormState";
@@ -115,6 +116,10 @@ export default function App() {
 
   // --- AUTO BACKUP ---
   useAutoBackup(entries, userData, autoBackup);
+
+  // --- AUTO PDF ARCHIVE (monatlich wachsendes PDF, taeglicher Startup-Check) ---
+  const { lastRun: pdfArchiveLastRun, lastError: pdfArchiveLastError, performRun: pdfArchivePerformRun } =
+    useAutoPdfArchive(entries, userData, workCodes);
 
   // --- ATTACHMENTS ---
   const {
@@ -452,6 +457,10 @@ export default function App() {
                   setNextcloudUrl={setNextcloudUrl}
                   setNextcloudUser={setNextcloudUser}
                   setNextcloudPass={setNextcloudPass}
+                  // PDF-Archiv (useAutoPdfArchive)
+                  pdfArchiveLastRun={pdfArchiveLastRun}
+                  pdfArchiveLastError={pdfArchiveLastError}
+                  pdfArchivePerformRun={pdfArchivePerformRun}
                 />
               </Suspense>
             </motion.div>

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -4,6 +4,7 @@ import ProfileSettings from "./Settings/ProfileSettings";
 import DataSettings from "./Settings/DataSettings";
 import ThemeSettings from "./Settings/ThemeSettings";
 import BackupSettings from "./Settings/BackupSettings";
+import PdfArchiveSettings from "./Settings/PdfArchiveSettings";
 import AppInfoSettings from "./Settings/AppInfoSettings";
 import { analyzeBackupData, applyBackup, readJsonFile } from "../utils/storageBackup";
 import toast from "react-hot-toast";
@@ -38,6 +39,10 @@ const Settings = ({
   setNextcloudUrl,
   setNextcloudUser,
   setNextcloudPass,
+  // PDF-Archiv
+  pdfArchiveLastRun,
+  pdfArchiveLastError,
+  pdfArchivePerformRun,
 }) => {
   const [showChangelog, setShowChangelog] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
@@ -236,6 +241,16 @@ const Settings = ({
         setNextcloudUser={setNextcloudUser}
         setNextcloudPass={setNextcloudPass}
       />
+
+      {/* 4b. PDF-Archiv (monatlich wachsendes PDF) */}
+      {pdfArchivePerformRun && (
+        <PdfArchiveSettings
+          nextcloudEnabled={nextcloudEnabled}
+          performRun={pdfArchivePerformRun}
+          lastRun={pdfArchiveLastRun}
+          lastError={pdfArchiveLastError}
+        />
+      )}
 
       {/* 5. App Info & Danger Zone */}
       <AppInfoSettings

--- a/src/components/Settings/PdfArchiveSettings.jsx
+++ b/src/components/Settings/PdfArchiveSettings.jsx
@@ -1,0 +1,247 @@
+import React, { useEffect, useState, useCallback } from "react";
+import { FileText, CheckCircle2, AlertTriangle, Loader, HardDrive, Server } from "lucide-react";
+import toast from "react-hot-toast";
+import { Card } from "../../utils";
+import { STORAGE_KEYS } from "../../hooks/constants";
+import { isSQLiteActive } from "../../db/storageMode";
+import { getSetting, setSetting } from "../../db/repositories/settingsRepo";
+import { logger } from "../../utils/logger";
+
+const log = logger.scope("PdfArchiveSettings");
+
+async function dualWrite(lsKey, sqlKey, value) {
+  const prev = localStorage.getItem(lsKey);
+  localStorage.setItem(lsKey, String(value));
+  if (isSQLiteActive()) {
+    try {
+      await setSetting(sqlKey, value);
+    } catch (e) {
+      if (prev !== null) localStorage.setItem(lsKey, prev);
+      else localStorage.removeItem(lsKey);
+      log.warn(`SQLite-Write "${sqlKey}" fehlgeschlagen:`, e);
+    }
+  }
+}
+
+const readBool = (key) => localStorage.getItem(key) === "true";
+
+const formatLastRun = (dateStr) => {
+  if (!dateStr) return "Noch nicht ausgefuehrt";
+  const d = new Date(dateStr);
+  if (Number.isNaN(d.getTime())) return dateStr;
+  return d.toLocaleDateString("de-DE", { day: "2-digit", month: "2-digit", year: "numeric" });
+};
+
+const PdfArchiveSettings = ({ nextcloudEnabled, performRun, lastRun, lastError }) => {
+  const [enabled, setEnabled] = useState(() => readBool(STORAGE_KEYS.PDF_ARCHIVE_ENABLED));
+  const [localTarget, setLocalTarget] = useState(() => readBool(STORAGE_KEYS.PDF_ARCHIVE_LOCAL));
+  const [nextcloudTarget, setNextcloudTarget] = useState(() => readBool(STORAGE_KEYS.PDF_ARCHIVE_NEXTCLOUD));
+  const [isRunning, setIsRunning] = useState(false);
+
+  // SQLite nachladen (analog zum bestehenden Muster)
+  useEffect(() => {
+    if (!isSQLiteActive()) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const [en, loc, nc] = await Promise.all([
+          getSetting("pdf_archive_enabled"),
+          getSetting("pdf_archive_local"),
+          getSetting("pdf_archive_nextcloud"),
+        ]);
+        if (cancelled) return;
+        if (en != null) setEnabled(String(en) === "true");
+        if (loc != null) setLocalTarget(String(loc) === "true");
+        if (nc != null) setNextcloudTarget(String(nc) === "true");
+      } catch (e) {
+        log.warn("SQLite-Read PDF archive settings fehlgeschlagen:", e);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  const toggleEnabled = useCallback(async () => {
+    const next = !enabled;
+    setEnabled(next);
+    await dualWrite(STORAGE_KEYS.PDF_ARCHIVE_ENABLED, "pdf_archive_enabled", String(next));
+    // Default: Lokal auto-aktivieren, damit beim ersten Einschalten gleich etwas passiert
+    if (next && !localTarget && !nextcloudTarget) {
+      setLocalTarget(true);
+      await dualWrite(STORAGE_KEYS.PDF_ARCHIVE_LOCAL, "pdf_archive_local", "true");
+    }
+  }, [enabled, localTarget, nextcloudTarget]);
+
+  const toggleLocal = useCallback(async () => {
+    const next = !localTarget;
+    setLocalTarget(next);
+    await dualWrite(STORAGE_KEYS.PDF_ARCHIVE_LOCAL, "pdf_archive_local", String(next));
+  }, [localTarget]);
+
+  const toggleNextcloud = useCallback(async () => {
+    if (!nextcloudEnabled) {
+      toast.error("Nextcloud muss zuerst verbunden sein (Karte 'Backup & Export').");
+      return;
+    }
+    const next = !nextcloudTarget;
+    setNextcloudTarget(next);
+    await dualWrite(STORAGE_KEYS.PDF_ARCHIVE_NEXTCLOUD, "pdf_archive_nextcloud", String(next));
+  }, [nextcloudTarget, nextcloudEnabled]);
+
+  const handleRunNow = useCallback(async () => {
+    if (!enabled) {
+      toast.error("PDF-Archiv ist deaktiviert.");
+      return;
+    }
+    if (!localTarget && !nextcloudTarget) {
+      toast.error("Bitte mindestens ein Ziel auswaehlen.");
+      return;
+    }
+    setIsRunning(true);
+    const toastId = toast.loading("Erzeuge Monats-PDF ...");
+    try {
+      const res = await performRun({ source: "manual", force: true });
+      if (res?.ok) {
+        const anyUpload = res.anyRealUpload;
+        const anyFail = res.anyFailure;
+        if (anyFail) {
+          toast.error("Teilweise fehlgeschlagen — siehe Details unten", { id: toastId });
+        } else if (anyUpload) {
+          toast.success("PDF-Archiv aktualisiert", { id: toastId });
+        } else {
+          toast.success("Nichts zu tun — Daten sind aktuell", { id: toastId, icon: "✓" });
+        }
+      } else {
+        toast.error(`Nicht ausgefuehrt: ${res?.reason || res?.error || "unbekannt"}`, { id: toastId });
+      }
+    } catch (err) {
+      toast.error(`Fehler: ${err?.message || err}`, { id: toastId });
+    } finally {
+      setIsRunning(false);
+    }
+  }, [enabled, localTarget, nextcloudTarget, performRun]);
+
+  return (
+    <Card className="p-4">
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-3">
+          <div className="p-2 rounded-full bg-indigo-100 text-indigo-600 dark:bg-indigo-900/40 dark:text-indigo-300">
+            <FileText size={20} />
+          </div>
+          <div>
+            <h2 className="font-bold text-base text-zinc-800 dark:text-white">
+              Automatisches PDF-Archiv
+            </h2>
+            <p className="text-xs text-zinc-500 dark:text-zinc-400">
+              Taeglich ein Monats-PDF zur gesetzlich geforderten Langzeit-Aufbewahrung
+            </p>
+          </div>
+        </div>
+        <label className="relative inline-flex items-center cursor-pointer">
+          <input
+            type="checkbox"
+            className="sr-only peer"
+            checked={enabled}
+            onChange={toggleEnabled}
+          />
+          <div className="w-11 h-6 bg-zinc-200 dark:bg-zinc-700 peer-checked:bg-indigo-500 rounded-full peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all" />
+        </label>
+      </div>
+
+      {enabled && (
+        <div className="space-y-3">
+          {/* Lokal */}
+          <div className="flex items-center justify-between bg-zinc-100 dark:bg-zinc-700 p-3 rounded-xl">
+            <div className="flex items-center gap-3">
+              <div className={`p-2 rounded-full ${localTarget ? "bg-green-100 text-green-600" : "bg-zinc-200 text-zinc-400"}`}>
+                <HardDrive size={18} />
+              </div>
+              <div>
+                <span className="block font-bold text-sm text-zinc-800 dark:text-white">
+                  Lokaler Ordner
+                </span>
+                <span className="block text-xs text-zinc-500 dark:text-zinc-400">
+                  Dokumente/eStundnzettl/Archiv/
+                </span>
+              </div>
+            </div>
+            <label className="relative inline-flex items-center cursor-pointer">
+              <input type="checkbox" className="sr-only peer" checked={localTarget} onChange={toggleLocal} />
+              <div className="w-11 h-6 bg-zinc-200 dark:bg-zinc-600 peer-checked:bg-indigo-500 rounded-full peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all" />
+            </label>
+          </div>
+
+          {/* Nextcloud */}
+          <div className="flex items-center justify-between bg-zinc-100 dark:bg-zinc-700 p-3 rounded-xl">
+            <div className="flex items-center gap-3">
+              <div className={`p-2 rounded-full ${nextcloudTarget ? "bg-green-100 text-green-600" : "bg-zinc-200 text-zinc-400"}`}>
+                <Server size={18} />
+              </div>
+              <div>
+                <span className="block font-bold text-sm text-zinc-800 dark:text-white">
+                  Nextcloud
+                </span>
+                <span className="block text-xs text-zinc-500 dark:text-zinc-400">
+                  {nextcloudEnabled ? "/eStundnzettl/Archiv/" : "Erst Nextcloud verbinden"}
+                </span>
+              </div>
+            </div>
+            <label className={`relative inline-flex items-center ${nextcloudEnabled ? "cursor-pointer" : "cursor-not-allowed opacity-50"}`}>
+              <input
+                type="checkbox"
+                className="sr-only peer"
+                checked={nextcloudTarget}
+                onChange={toggleNextcloud}
+                disabled={!nextcloudEnabled}
+              />
+              <div className="w-11 h-6 bg-zinc-200 dark:bg-zinc-600 peer-checked:bg-indigo-500 rounded-full peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all" />
+            </label>
+          </div>
+
+          {/* Google Drive — Platzhalter fuer Iteration 2 */}
+          <div className="flex items-center justify-between bg-zinc-50 dark:bg-zinc-900/30 p-3 rounded-xl border border-dashed border-zinc-300 dark:border-zinc-700">
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-full bg-zinc-200 dark:bg-zinc-700 text-zinc-400">
+                <FileText size={18} />
+              </div>
+              <div>
+                <span className="block font-bold text-sm text-zinc-500 dark:text-zinc-400">
+                  Google Drive
+                </span>
+                <span className="block text-xs text-zinc-400">
+                  Folgt in einem separaten Update (isoliert getestet)
+                </span>
+              </div>
+            </div>
+            <span className="text-[10px] font-bold text-zinc-400 uppercase">bald</span>
+          </div>
+
+          {/* Info-Zeile */}
+          <div className="flex items-center justify-between pt-2">
+            <div className="text-xs text-zinc-500 dark:text-zinc-400">
+              <div className="flex items-center gap-1">
+                <CheckCircle2 size={12} className="text-green-500" />
+                <span>Letzter Lauf: {formatLastRun(lastRun)}</span>
+              </div>
+              {lastError && (
+                <div className="flex items-start gap-1 mt-1 text-red-500">
+                  <AlertTriangle size={12} className="mt-0.5 shrink-0" />
+                  <span className="break-all">{lastError}</span>
+                </div>
+              )}
+            </div>
+            <button
+              onClick={handleRunNow}
+              disabled={isRunning}
+              className="px-3 py-1.5 text-xs font-bold rounded-lg border border-indigo-300 bg-indigo-50 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300 dark:border-indigo-700 disabled:opacity-50 flex items-center gap-1.5"
+            >
+              {isRunning ? <Loader size={12} className="animate-spin" /> : <FileText size={12} />}
+              Jetzt ausfuehren
+            </button>
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+};
+
+export default PdfArchiveSettings;

--- a/src/hooks/constants.js
+++ b/src/hooks/constants.js
@@ -49,10 +49,20 @@ export const STORAGE_KEYS = {
   NEXTCLOUD_URL: "estundnzettl_nextcloud_url",
   NEXTCLOUD_USER: "estundnzettl_nextcloud_user",
   NEXTCLOUD_PASS: "estundnzettl_nextcloud_pass",
-  
+
+  // Automatisches PDF-Archiv (monatlich wachsendes PDF, taeglicher Startup-Check)
+  PDF_ARCHIVE_ENABLED: "estundnzettl_pdf_archive_enabled",
+  PDF_ARCHIVE_LOCAL: "estundnzettl_pdf_archive_local",
+  PDF_ARCHIVE_NEXTCLOUD: "estundnzettl_pdf_archive_nextcloud",
+  PDF_ARCHIVE_LAST_RUN: "estundnzettl_pdf_archive_last_run",
+  PDF_ARCHIVE_LAST_MONTH: "estundnzettl_pdf_archive_last_month",
+  PDF_ARCHIVE_LAST_HASH: "estundnzettl_pdf_archive_last_hash",
+  PDF_ARCHIVE_FAIL_COUNT: "estundnzettl_pdf_archive_fail_count",
+  PDF_ARCHIVE_LAST_ERROR: "estundnzettl_pdf_archive_last_error",
+
   // @Deprecated - Wir nutzen jetzt CLOUD_SYNC_ENABLED für Präzision
-  // AUTO_BACKUP: "estundnzettl_auto_backup", 
-  // CLOUD_SYNC: "estundnzettl_cloud_sync", 
+  // AUTO_BACKUP: "estundnzettl_auto_backup",
+  // CLOUD_SYNC: "estundnzettl_cloud_sync",
 };
 
 // -------------------------------------------------------

--- a/src/hooks/useAutoPdfArchive.js
+++ b/src/hooks/useAutoPdfArchive.js
@@ -1,0 +1,242 @@
+/**
+ * useAutoPdfArchive — Automatisches monatliches PDF-Archiv.
+ *
+ * Strategie:
+ * - Beim App-Start (Mount) und bei jedem Resume pruefen, ob heute schon
+ *   ein Lauf stattgefunden hat. Falls nein → PDF des aktuellen Monats
+ *   (bis heute) generieren und an aktive Ziele verteilen.
+ * - Bei Monats-Uebergang: zuerst das vergangene Monat final exportieren,
+ *   dann das neue Monat.
+ * - Content-Hash-Skip: wenn sich gegenueber dem letzten Lauf nichts
+ *   geaendert hat, wird der Generate-/Upload-Pfad komplett uebersprungen.
+ * - Zielt NICHT auf Google Drive — das JSON-Backup-Verhalten in
+ *   useAutoBackup bleibt komplett unberuehrt.
+ */
+
+import { useEffect, useRef, useCallback, useState } from "react";
+import { App } from "@capacitor/app";
+import { STORAGE_KEYS } from "./constants";
+import { isSQLiteActive } from "../db/storageMode";
+import { setSetting } from "../db/repositories/settingsRepo";
+import { logger } from "../utils/logger";
+import {
+  generateMonthlyPdfBlob,
+  filterEntriesForMonth,
+  hashMonthContent,
+  buildArchiveFilename,
+} from "../utils/pdfArchive";
+import { blobToBase64 } from "../utils";
+import { writeLocalArchive, uploadNextcloudArchive } from "../utils/pdfArchiveTargets";
+
+const log = logger.scope("PdfArchive");
+
+const todayStr = () => {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+};
+
+const monthStr = (date = new Date()) =>
+  `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+
+/** Dual-Write: localStorage + (wenn verfuegbar) SQLite. */
+async function dualWrite(lsKey, sqlKey, value) {
+  const prev = localStorage.getItem(lsKey);
+  localStorage.setItem(lsKey, String(value));
+  if (isSQLiteActive()) {
+    try {
+      await setSetting(sqlKey, value);
+    } catch (e) {
+      if (prev !== null) localStorage.setItem(lsKey, prev);
+      else localStorage.removeItem(lsKey);
+      log.warn(`SQLite-Write "${sqlKey}" fehlgeschlagen:`, e);
+    }
+  }
+}
+
+/** Prueft, ob der letzte Lauf vor heute 00:00 liegt. */
+function isDueToday() {
+  const last = localStorage.getItem(STORAGE_KEYS.PDF_ARCHIVE_LAST_RUN) || "";
+  return last !== todayStr();
+}
+
+/**
+ * Fuehrt einen Lauf fuer einen bestimmten Monat durch.
+ * Gibt das Ergebnis zurueck ({ skipped, ok, errors }), damit der
+ * manuelle Trigger Toasts anzeigen kann.
+ */
+async function runForMonth({ entries, userData, workCodes, year, month, targets }) {
+  const filename = buildArchiveFilename({ year, month, userData });
+  const newHash = hashMonthContent({ entries, userData, year, month });
+  const lastHashKey = `${STORAGE_KEYS.PDF_ARCHIVE_LAST_HASH}_${year}-${String(month).padStart(2, "0")}`;
+  const prevHash = localStorage.getItem(lastHashKey);
+
+  if (prevHash === newHash) {
+    log.info(`Hash unveraendert fuer ${year}-${month} — kein Upload.`);
+    return { skipped: true, filename };
+  }
+
+  const monthEntries = filterEntriesForMonth(entries, year, month);
+  if (monthEntries.length === 0 && prevHash == null) {
+    // Nichts zu exportieren und auch nichts vorher — komplett ueberspringen
+    return { skipped: true, filename, empty: true };
+  }
+
+  const blob = await generateMonthlyPdfBlob({ year, month, entries, userData, workCodes });
+  const base64 = await blobToBase64(blob);
+
+  const results = [];
+  if (targets.local) {
+    results.push(await writeLocalArchive(filename, base64, blob));
+  }
+  if (targets.nextcloud) {
+    results.push(await uploadNextcloudArchive(filename, base64));
+  }
+
+  const anyOk = results.some((r) => r.ok);
+  const errors = results.filter((r) => !r.ok);
+
+  if (anyOk) {
+    localStorage.setItem(lastHashKey, newHash);
+  }
+
+  return { skipped: false, filename, results, anyOk, errors };
+}
+
+export function useAutoPdfArchive(entries, userData, workCodes) {
+  const latestDataRef = useRef({ entries, userData, workCodes });
+  const isRunning = useRef(false);
+  const [lastRun, setLastRun] = useState(
+    () => localStorage.getItem(STORAGE_KEYS.PDF_ARCHIVE_LAST_RUN) || ""
+  );
+  const [lastError, setLastError] = useState(
+    () => localStorage.getItem(STORAGE_KEYS.PDF_ARCHIVE_LAST_ERROR) || ""
+  );
+
+  useEffect(() => {
+    latestDataRef.current = { entries, userData, workCodes };
+  }, [entries, userData, workCodes]);
+
+  const getActiveTargets = () => {
+    const masterOn = localStorage.getItem(STORAGE_KEYS.PDF_ARCHIVE_ENABLED) === "true";
+    if (!masterOn) return null;
+    const targets = {
+      local: localStorage.getItem(STORAGE_KEYS.PDF_ARCHIVE_LOCAL) === "true",
+      nextcloud: localStorage.getItem(STORAGE_KEYS.PDF_ARCHIVE_NEXTCLOUD) === "true",
+    };
+    if (!targets.local && !targets.nextcloud) return null;
+    return targets;
+  };
+
+  /**
+   * Fuehrt den kompletten Lauf aus: bei Monatswechsel erst Vormonat
+   * finalisieren, dann aktuelles Monat.
+   */
+  const performRun = useCallback(async ({ source = "auto", force = false } = {}) => {
+    if (isRunning.current) {
+      log.info(`performRun (${source}) — bereits laufend, skip.`);
+      return { ok: false, reason: "already-running" };
+    }
+
+    const targets = getActiveTargets();
+    if (!targets) {
+      log.info(`performRun (${source}) — nicht aktiv, skip.`);
+      return { ok: false, reason: "disabled" };
+    }
+
+    if (!force && !isDueToday()) {
+      log.info(`performRun (${source}) — heute bereits gelaufen, skip.`);
+      return { ok: false, reason: "already-today" };
+    }
+
+    isRunning.current = true;
+    try {
+      const { entries, userData, workCodes } = latestDataRef.current;
+      if (!entries || !userData) {
+        return { ok: false, reason: "no-data" };
+      }
+
+      const now = new Date();
+      const currentYM = monthStr(now);
+      const lastYM = localStorage.getItem(STORAGE_KEYS.PDF_ARCHIVE_LAST_MONTH) || "";
+
+      const results = [];
+
+      // Monats-Uebergang: Vormonat finalisieren (letzter Tag war also im Vormonat)
+      if (lastYM && lastYM !== currentYM) {
+        const [py, pm] = lastYM.split("-").map(Number);
+        if (py && pm) {
+          log.info(`Monats-Uebergang erkannt: finalisiere ${lastYM}`);
+          const prevRes = await runForMonth({
+            entries, userData, workCodes,
+            year: py, month: pm, targets,
+          });
+          results.push({ month: lastYM, ...prevRes });
+        }
+      }
+
+      // Aktuelles Monat
+      const curRes = await runForMonth({
+        entries, userData, workCodes,
+        year: now.getFullYear(), month: now.getMonth() + 1, targets,
+      });
+      results.push({ month: currentYM, ...curRes });
+
+      // Status-Update
+      const today = todayStr();
+      const anyRealUpload = results.some((r) => !r.skipped && r.anyOk);
+      const anyFailure = results.some((r) => !r.skipped && r.errors && r.errors.length > 0);
+
+      await dualWrite(STORAGE_KEYS.PDF_ARCHIVE_LAST_RUN, "pdf_archive_last_run", today);
+      await dualWrite(STORAGE_KEYS.PDF_ARCHIVE_LAST_MONTH, "pdf_archive_last_month", currentYM);
+      setLastRun(today);
+
+      if (anyFailure) {
+        const current = parseInt(localStorage.getItem(STORAGE_KEYS.PDF_ARCHIVE_FAIL_COUNT) || "0", 10);
+        const msg = results.flatMap((r) => (r.errors || []).map((e) => `${e.target}: ${e.error}`)).join(" · ");
+        await dualWrite(STORAGE_KEYS.PDF_ARCHIVE_FAIL_COUNT, "pdf_archive_fail_count", String(current + 1));
+        await dualWrite(STORAGE_KEYS.PDF_ARCHIVE_LAST_ERROR, "pdf_archive_last_error", msg);
+        setLastError(msg);
+      } else if (anyRealUpload) {
+        await dualWrite(STORAGE_KEYS.PDF_ARCHIVE_FAIL_COUNT, "pdf_archive_fail_count", "0");
+        await dualWrite(STORAGE_KEYS.PDF_ARCHIVE_LAST_ERROR, "pdf_archive_last_error", "");
+        setLastError("");
+      }
+
+      return { ok: true, results, anyRealUpload, anyFailure };
+    } catch (err) {
+      log.error("performRun failed:", err);
+      const msg = String(err?.message || err);
+      await dualWrite(STORAGE_KEYS.PDF_ARCHIVE_LAST_ERROR, "pdf_archive_last_error", msg);
+      setLastError(msg);
+      return { ok: false, error: msg };
+    } finally {
+      isRunning.current = false;
+    }
+  }, []);
+
+  // Startup-Check (einmalig beim Mount, verzoegert damit DB-/Settings-Loads
+  // abgeschlossen sind)
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      performRun({ source: "startup" });
+    }, 3000);
+    return () => clearTimeout(timer);
+  }, [performRun]);
+
+  // Resume-Check (App-Wechsel von Background → Foreground)
+  useEffect(() => {
+    let handle = null;
+    (async () => {
+      handle = await App.addListener("appStateChange", ({ isActive }) => {
+        if (isActive) {
+          performRun({ source: "resume" });
+        }
+      });
+    })();
+    return () => {
+      if (handle) handle.remove();
+    };
+  }, [performRun]);
+
+  return { lastRun, lastError, performRun };
+}

--- a/src/utils/nextcloudClient.js
+++ b/src/utils/nextcloudClient.js
@@ -405,6 +405,130 @@ export async function ensureFolder(url, user, pass) {
   }
 }
 
+/**
+ * Stellt sicher, dass ein beliebiger Ordner-Pfad unterhalb des DAV-User-Roots
+ * existiert. Legt fehlende Segmente per MKCOL an. Parallel zum bestehenden
+ * `ensureFolder` (der hart auf BACKUP_FOLDER zielt) — unabhaengiger Cache-Key.
+ *
+ * @param {string} url  Nextcloud Server URL
+ * @param {string} user Benutzername
+ * @param {string} pass App-Password
+ * @param {string[]} segments z.B. ['eStundnzettl', 'Archiv']
+ */
+async function ensureFolderPath(url, user, pass, segments) {
+  const davUser = await getDavUser(url, user, pass);
+  const base = davPath(url, davUser);
+  let acc = "";
+  for (const seg of segments) {
+    if (!seg) continue;
+    acc += "/" + encodeURIComponent(seg);
+    const cacheKey = `${getFolderCacheKey(url, user)}::${acc}`;
+    if (verifiedFolderCache.has(cacheKey)) continue;
+    const folderUrl = `${base}${acc}/`;
+    try {
+      const res = await nativeHttp(folderUrl, "MKCOL", user, pass);
+      if (res.status === 201 || res.status === 405 || res.status === 409) {
+        verifiedFolderCache.set(cacheKey, true);
+        continue;
+      }
+      if (res.status === 401) throw new Error("Nicht autorisiert (401)");
+      throw new Error(`MKCOL ${res.status} auf ${folderUrl}`);
+    } catch (err) {
+      if (err.message.includes("401")) throw err;
+      if (err.message.includes("drosselt gerade Anfragen")) {
+        return { ok: false, reason: "rate_limited" };
+      }
+      throw err;
+    }
+  }
+  return { ok: true };
+}
+
+/**
+ * Native HTTP PUT mit binaerem Body (base64). Nutzt dieselbe Plugin-Route
+ * wie `nativeHttp`, uebergibt aber `bodyBase64` statt `body`, sodass der
+ * Android-Teil die Bytes 1:1 durchleitet (siehe NextcloudLoginFlowPlugin.java).
+ * Web-Fallback: fetch() mit decodierten Bytes.
+ */
+async function nativeHttpBinary(url, user, pass, bodyBase64, contentType) {
+  const remaining = getRateLimitRemaining(url, user);
+  if (remaining > 0) {
+    throw new Error(formatRateLimitMessage(remaining));
+  }
+
+  if (Capacitor.getPlatform() === 'android') {
+    const result = await NextcloudLoginFlow.httpRequest({
+      url,
+      method: "PUT",
+      username: user,
+      password: pass,
+      bodyBase64,
+      contentType: contentType || "application/octet-stream",
+    });
+    if (!result.ok) {
+      const errMsg = result.error?.message || `Native HTTP fehlgeschlagen: ${result.error?.code}`;
+      throw new Error(errMsg);
+    }
+    if (result.status === 429) {
+      setRateLimited(url, user);
+      throw new Error(formatRateLimitMessage(DEFAULT_RATE_LIMIT_MS));
+    }
+    clearRateLimited(url, user);
+    return { status: result.status, body: result.body || "" };
+  }
+
+  // Web-Fallback: base64 → Uint8Array
+  const binStr = atob(bodyBase64);
+  const bytes = new Uint8Array(binStr.length);
+  for (let i = 0; i < binStr.length; i++) bytes[i] = binStr.charCodeAt(i);
+  const headers = { ...authHeaders(user, pass), "Content-Type": contentType || "application/octet-stream" };
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 60000);
+  let res;
+  try {
+    res = await fetch(url, { method: "PUT", headers, body: bytes, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+  if (res.status === 429) {
+    setRateLimited(url, user);
+    throw new Error(formatRateLimitMessage(DEFAULT_RATE_LIMIT_MS));
+  }
+  clearRateLimited(url, user);
+  return { status: res.status, body: await res.text() };
+}
+
+/**
+ * Laedt beliebige binaere Daten (z.B. PDF) unter einen relativen Pfad im
+ * Nextcloud hoch. Legt fehlende Ordner unterwegs an. Parallel zur bestehenden
+ * `uploadBackup`-Funktion; beruehrt diese nicht.
+ *
+ * @param {string} url        Nextcloud Server URL
+ * @param {string} user       Benutzername
+ * @param {string} pass       App-Password
+ * @param {string[]} folders  Ordner-Segmente unterhalb des DAV-Root, z.B. ['eStundnzettl', 'Archiv']
+ * @param {string} filename   Dateiname inkl. Endung, z.B. 'Stundenzettel_2026-04_Max.pdf'
+ * @param {string} base64     Base64-codierter Datei-Inhalt (ohne data:-Prefix)
+ * @param {string} mimeType   Content-Type, z.B. 'application/pdf'
+ */
+export async function uploadBinaryToPath(url, user, pass, folders, filename, base64, mimeType) {
+  const folderResult = await ensureFolderPath(url, user, pass, folders);
+  if (folderResult?.reason === "rate_limited") {
+    throw new Error(formatRateLimitMessage(getRateLimitRemaining(url, user) || DEFAULT_RATE_LIMIT_MS));
+  }
+
+  const davUser = await getDavUser(url, user, pass);
+  const folderPath = folders.map(encodeURIComponent).join("/");
+  const targetUrl = `${davPath(url, davUser)}/${folderPath}/${encodeURIComponent(filename)}`;
+
+  const res = await nativeHttpBinary(targetUrl, user, pass, base64, mimeType || "application/octet-stream");
+  if (res.status === 201 || res.status === 204) {
+    return true;
+  }
+  if (res.status === 401) throw new Error("Nicht autorisiert (401)");
+  throw new Error(`Upload ${res.status} auf ${targetUrl} body=${(res.body || "").substring(0, 200)}`);
+}
+
 export async function uploadBackup(url, user, pass, jsonData) {
   const content = typeof jsonData === "string" ? jsonData : JSON.stringify(jsonData, null, 2);
   const davUser = await getDavUser(url, user, pass);

--- a/src/utils/pdfArchive.js
+++ b/src/utils/pdfArchive.js
@@ -1,0 +1,325 @@
+/**
+ * pdfArchive.js — Headless monatlicher PDF-Generator (pdfmake-basiert).
+ *
+ * Erzeugt ein A4-Portrait-PDF mit echtem, durchsuchbarem Text fuer die
+ * automatische Langzeit-Archivierung (useAutoPdfArchive).
+ *
+ * Wichtig: Diese Datei ist komplett unabhaengig vom interaktiven
+ * PrintReport.jsx (der weiterhin html2pdf.js nutzt). Layout bewusst
+ * schlicht & tabellarisch — Ziel ist gerichtsverwertbare Lesbarkeit,
+ * nicht Bildschirm-Parity.
+ *
+ * Dynamischer Import (`await import('pdfmake/...')`) haelt die ~1.1 MB
+ * Bundle-Kosten aus dem Haupt-Bundle heraus; sie werden nur geladen,
+ * wenn das Feature tatsaechlich laeuft.
+ */
+
+import { calculatePeriodStats, getTargetMinutesForDate, buildDayBalanceMetaMap } from "./timeCalculations";
+import { WORK_CODE } from "../hooks/constants";
+
+// ───────────── Helpers ─────────────
+
+const pad2 = (n) => String(n).padStart(2, "0");
+
+const minutesToHHMM = (mins) => {
+  const sign = mins < 0 ? "-" : "";
+  const abs = Math.abs(Math.round(mins));
+  const h = Math.floor(abs / 60);
+  const m = abs % 60;
+  return `${sign}${pad2(h)}:${pad2(m)}`;
+};
+
+const monthLabelDe = (year, month /* 1-12 */) => {
+  const d = new Date(year, month - 1, 1);
+  return d.toLocaleDateString("de-DE", { month: "long", year: "numeric" });
+};
+
+const entryTypeLabel = (type) => {
+  switch (type) {
+    case "work": return "Arbeit";
+    case "vacation": return "Urlaub";
+    case "sick": return "Krank";
+    case "public_holiday": return "Feiertag";
+    case "time_comp": return "Zeitausgleich";
+    default: return type || "";
+  }
+};
+
+/** Filtert alle Entries auf den angegebenen Kalendermonat (YYYY-MM-Prefix). */
+export function filterEntriesForMonth(entries, year, month) {
+  const prefix = `${year}-${pad2(month)}`;
+  return (entries || [])
+    .filter((e) => typeof e.date === "string" && e.date.startsWith(prefix))
+    .sort((a, b) => {
+      if (a.date !== b.date) return a.date.localeCompare(b.date);
+      const ak = a.start || "";
+      const bk = b.start || "";
+      return ak.localeCompare(bk);
+    });
+}
+
+/**
+ * Deterministischer Hash ueber alle Inhalte, die sich im PDF niederschlagen.
+ * Gleicher Algorithmus wie in useAutoBackup (djb2), damit das Muster
+ * konsistent bleibt.
+ */
+export function hashMonthContent({ entries, userData, year, month }) {
+  const relevant = {
+    ym: `${year}-${pad2(month)}`,
+    name: userData?.name || "",
+    workDays: userData?.workDays || null,
+    workModel: userData?.workModel || null,
+    entries: filterEntriesForMonth(entries, year, month).map((e) => ({
+      id: e.id,
+      t: e.type,
+      d: e.date,
+      s: e.start || null,
+      e: e.end || null,
+      p: e.pause || 0,
+      pr: e.project || null,
+      c: e.code ?? null,
+      n: e.netDuration || 0,
+    })),
+  };
+  const str = JSON.stringify(relevant);
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) + hash + str.charCodeAt(i)) | 0;
+  }
+  return String(hash);
+}
+
+/** Baut den filename: Stundenzettel_YYYY-MM_Name.pdf (slug-safe). */
+export function buildArchiveFilename({ year, month, userData }) {
+  const rawName = (userData?.name || "Stundenzettel").trim();
+  const clean = rawName
+    .replace(/\s+/g, "_")
+    .replace(/[^a-zA-Z0-9_-]/g, "") || "Stundenzettel";
+  return `Stundenzettel_${year}-${pad2(month)}_${clean}.pdf`;
+}
+
+// ───────────── Document Definition ─────────────
+
+const TABLE_HEADER_FILL = "#1f2937";
+
+const buildEntryRows = (entries, userData, workCodeLabelMap, dayMetaMap) => {
+  const rows = [
+    [
+      { text: "Datum", style: "tableHeader" },
+      { text: "Typ", style: "tableHeader" },
+      { text: "Start", style: "tableHeader" },
+      { text: "Ende", style: "tableHeader" },
+      { text: "Pause", style: "tableHeader" },
+      { text: "Projekt / Code", style: "tableHeader" },
+      { text: "Netto", style: "tableHeader", alignment: "right" },
+      { text: "Tagessaldo", style: "tableHeader", alignment: "right" },
+    ],
+  ];
+
+  if (entries.length === 0) {
+    rows.push([
+      { text: "Keine Eintraege in diesem Monat.", colSpan: 8, alignment: "center", italics: true, color: "#6b7280" },
+      {}, {}, {}, {}, {}, {}, {},
+    ]);
+    return rows;
+  }
+
+  entries.forEach((e) => {
+    const codeLabel = e.code != null ? (workCodeLabelMap.get(e.code) || `Code ${e.code}`) : "";
+    const projectLabel = [e.project, codeLabel].filter(Boolean).join(" · ");
+    const meta = dayMetaMap[e.id];
+    const dayBalance = meta?.showBalance ? minutesToHHMM(meta.balance) : "";
+
+    rows.push([
+      { text: e.date, style: "tableCell" },
+      { text: entryTypeLabel(e.type), style: "tableCell" },
+      { text: e.start || "—", style: "tableCell" },
+      { text: e.end || "—", style: "tableCell" },
+      { text: e.pause ? `${e.pause} min` : "—", style: "tableCell" },
+      { text: projectLabel || "—", style: "tableCell" },
+      { text: minutesToHHMM(e.netDuration || 0), style: "tableCell", alignment: "right" },
+      { text: dayBalance, style: "tableCell", alignment: "right" },
+    ]);
+  });
+
+  return rows;
+};
+
+const buildSummary = (stats) => {
+  const rows = [
+    ["Arbeitsstunden", minutesToHHMM(stats.work)],
+    ["Fahrzeit", minutesToHHMM(stats.drive)],
+    ["Urlaub", minutesToHHMM(stats.vacation)],
+    ["Krankenstand", minutesToHHMM(stats.sick)],
+    ["Feiertag", minutesToHHMM(stats.holiday)],
+    ["Zeitausgleich", minutesToHHMM(stats.timeComp)],
+    ["Soll", minutesToHHMM(stats.totalTarget)],
+    ["Ist (ohne Fahrzeit)", minutesToHHMM(stats.totalIst)],
+    ["Saldo", minutesToHHMM(stats.totalSaldo)],
+    ["Mehrarbeit (< 40h/Wo)", minutesToHHMM(stats.overtimeSplit.mehrarbeit)],
+    ["Überstunden (> 40h/Wo)", minutesToHHMM(stats.overtimeSplit.ueberstunden)],
+  ];
+  return rows.map(([k, v]) => [
+    { text: k, style: "summaryKey" },
+    { text: v, style: "summaryValue", alignment: "right" },
+  ]);
+};
+
+function buildDocDefinition({ year, month, entries, userData, workCodes }) {
+  const monthEntries = filterEntriesForMonth(entries, year, month);
+
+  const workCodeLabelMap = new Map((workCodes || []).map((c) => [c.id, c.label]));
+  const dayMetaMap = buildDayBalanceMetaMap(monthEntries, userData);
+
+  const periodStart = new Date(year, month - 1, 1);
+  const periodEnd = new Date(year, month, 0); // letzter Tag des Monats
+  const stats = calculatePeriodStats(monthEntries, userData, periodStart, periodEnd);
+
+  const generatedAt = new Date().toLocaleString("de-DE", {
+    day: "2-digit", month: "2-digit", year: "numeric",
+    hour: "2-digit", minute: "2-digit",
+  });
+
+  const workModelLabel = userData?.workModel?.label
+    || (Array.isArray(userData?.workDays)
+      ? `${userData.workDays.reduce((a, b) => a + b, 0)} Min/Woche`
+      : "—");
+
+  // Info-Zeile: Soll fuer den Monat (fuer Vergleich mit Lohnabrechnung)
+  let monthTargetMinutes = 0;
+  for (let d = new Date(periodStart); d <= periodEnd; d.setDate(d.getDate() + 1)) {
+    const ds = `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
+    monthTargetMinutes += getTargetMinutesForDate(ds, userData?.workDays);
+  }
+
+  return {
+    pageSize: "A4",
+    pageOrientation: "portrait",
+    pageMargins: [28, 40, 28, 40],
+    info: {
+      title: `Stundenzettel ${monthLabelDe(year, month)}`,
+      author: userData?.name || "eStundnzettl",
+      subject: "Automatisch generiertes Monatsarchiv",
+      creator: "eStundnzettl",
+    },
+    defaultStyle: {
+      fontSize: 8,
+      lineHeight: 1.15,
+    },
+    content: [
+      {
+        columns: [
+          [
+            { text: "Stundenzettel", style: "title" },
+            { text: monthLabelDe(year, month), style: "subtitle" },
+          ],
+          [
+            { text: userData?.name || "—", style: "nameRight" },
+            { text: `Arbeitszeitmodell: ${workModelLabel}`, style: "metaRight" },
+            { text: `Soll im Monat: ${minutesToHHMM(monthTargetMinutes)}`, style: "metaRight" },
+            { text: `Erstellt: ${generatedAt}`, style: "metaRight" },
+          ],
+        ],
+        columnGap: 10,
+        marginBottom: 14,
+      },
+
+      { text: "Einträge", style: "sectionHeader", marginBottom: 4 },
+      {
+        table: {
+          headerRows: 1,
+          widths: [52, 48, 32, 32, 32, "*", 40, 46],
+          body: buildEntryRows(monthEntries, userData, workCodeLabelMap, dayMetaMap),
+        },
+        layout: {
+          hLineWidth: (i) => (i === 0 || i === 1 ? 0.8 : 0.3),
+          vLineWidth: () => 0,
+          hLineColor: (i) => (i === 1 ? "#374151" : "#d1d5db"),
+          fillColor: (rowIndex) => (rowIndex === 0 ? TABLE_HEADER_FILL : null),
+        },
+        marginBottom: 14,
+      },
+
+      { text: "Monats-Zusammenfassung", style: "sectionHeader", marginBottom: 4 },
+      {
+        table: {
+          widths: ["*", 70],
+          body: buildSummary(stats),
+        },
+        layout: {
+          hLineWidth: () => 0.3,
+          vLineWidth: () => 0,
+          hLineColor: () => "#e5e7eb",
+        },
+      },
+
+      {
+        text: "Dieses PDF wird automatisch vom eStundnzettl erzeugt und dient der " +
+              "gesetzlich gefor­derten Langzeit-Aufbewahrung. Inhalte sind durchsuchbarer Text.",
+        style: "footnote",
+        marginTop: 18,
+      },
+    ],
+    footer: (currentPage, pageCount) => ({
+      text: `Seite ${currentPage} / ${pageCount}`,
+      alignment: "center",
+      fontSize: 7,
+      color: "#6b7280",
+      margin: [0, 10, 0, 0],
+    }),
+    styles: {
+      title: { fontSize: 18, bold: true, color: "#111827" },
+      subtitle: { fontSize: 12, color: "#4b5563", marginTop: 2 },
+      nameRight: { fontSize: 12, bold: true, alignment: "right", color: "#111827" },
+      metaRight: { fontSize: 8, alignment: "right", color: "#6b7280" },
+      sectionHeader: { fontSize: 10, bold: true, color: "#111827", marginTop: 6 },
+      tableHeader: { fontSize: 8, bold: true, color: "#ffffff", margin: [2, 4, 2, 4] },
+      tableCell: { fontSize: 8, color: "#1f2937", margin: [2, 3, 2, 3] },
+      summaryKey: { fontSize: 9, color: "#374151", margin: [4, 3, 4, 3] },
+      summaryValue: { fontSize: 9, bold: true, color: "#111827", margin: [4, 3, 4, 3] },
+      footnote: { fontSize: 7, italics: true, color: "#9ca3af" },
+    },
+  };
+}
+
+// ───────────── Public API ─────────────
+
+let pdfMakeInstance = null;
+
+async function getPdfMake() {
+  if (pdfMakeInstance) return pdfMakeInstance;
+  const pdfMakeModule = await import("pdfmake/build/pdfmake");
+  const pdfFontsModule = await import("pdfmake/build/vfs_fonts");
+  const pdfMake = pdfMakeModule.default || pdfMakeModule;
+  // vfs_fonts legt sein vfs je nach Build-Variante unter verschiedenen Pfaden ab.
+  const vfs =
+    pdfFontsModule?.default?.pdfMake?.vfs ??
+    pdfFontsModule?.pdfMake?.vfs ??
+    pdfFontsModule?.default?.vfs ??
+    pdfFontsModule?.vfs ??
+    null;
+  if (vfs) {
+    pdfMake.vfs = vfs;
+  }
+  pdfMakeInstance = pdfMake;
+  return pdfMake;
+}
+
+/**
+ * Erzeugt das Monats-PDF als Blob. Reine Funktion — kein DOM, kein React.
+ */
+export async function generateMonthlyPdfBlob({ year, month, entries, userData, workCodes }) {
+  if (!year || !month) throw new Error("generateMonthlyPdfBlob: year/month fehlen");
+  const pdfMake = await getPdfMake();
+  const docDefinition = buildDocDefinition({ year, month, entries, userData, workCodes });
+  return new Promise((resolve, reject) => {
+    try {
+      pdfMake.createPdf(docDefinition).getBlob((blob) => resolve(blob));
+    } catch (err) {
+      reject(err);
+    }
+  });
+}
+
+// Re-exports fuer Tests
+export { buildDocDefinition, WORK_CODE as _WORK_CODE };

--- a/src/utils/pdfArchiveTargets.js
+++ b/src/utils/pdfArchiveTargets.js
@@ -1,0 +1,80 @@
+/**
+ * pdfArchiveTargets.js — Ziel-Adapter fuer das automatische PDF-Archiv.
+ *
+ * Stellt eine einheitliche Schnittstelle fuer die (derzeit zwei) Ziele
+ * bereit: Lokaler Ordner und Nextcloud. Google Drive folgt in einer
+ * separaten Iteration — der GoogleDriveBackupPlugin wird in dieser
+ * Iteration bewusst nicht angefasst.
+ */
+
+import { Filesystem, Directory } from "@capacitor/filesystem";
+import { Capacitor } from "@capacitor/core";
+import { uploadBinaryToPath } from "./nextcloudClient";
+import { deobfuscate } from "./obfuscate";
+import { STORAGE_KEYS } from "../hooks/constants";
+import { logger } from "./logger";
+
+const log = logger.scope("PdfArchive");
+
+/**
+ * Schreibt das PDF in den lokalen Ordner Documents/eStundnzettl/Archiv/.
+ * Web-Fallback: Download via Blob-URL.
+ */
+export async function writeLocalArchive(filename, base64, blob) {
+  if (!Capacitor.isNativePlatform()) {
+    // Web: schlichter Download als Fallback
+    if (!blob) return { ok: false, error: "Kein Blob fuer Web-Download" };
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    return { ok: true, target: "local-web" };
+  }
+
+  try {
+    await Filesystem.writeFile({
+      path: `eStundnzettl/Archiv/${filename}`,
+      data: base64,
+      directory: Directory.Documents,
+      recursive: true,
+    });
+    return { ok: true, target: "local" };
+  } catch (err) {
+    log.warn("Lokales PDF-Archiv fehlgeschlagen:", err);
+    return { ok: false, error: String(err?.message || err), target: "local" };
+  }
+}
+
+/**
+ * Laedt das PDF nach Nextcloud in /eStundnzettl/Archiv/ hoch.
+ * Liest die Nextcloud-Credentials aus dem bestehenden Settings-Store
+ * (gleicher Pfad wie `useAutoBackup`).
+ */
+export async function uploadNextcloudArchive(filename, base64) {
+  const ncUrl = localStorage.getItem(STORAGE_KEYS.NEXTCLOUD_URL) || "";
+  const ncUser = localStorage.getItem(STORAGE_KEYS.NEXTCLOUD_USER) || "";
+  const ncPassRaw = localStorage.getItem(STORAGE_KEYS.NEXTCLOUD_PASS) || "";
+  if (!ncUrl || !ncUser || !ncPassRaw) {
+    return { ok: false, error: "Nextcloud nicht konfiguriert", target: "nextcloud" };
+  }
+  try {
+    const ncPass = await deobfuscate(ncPassRaw);
+    await uploadBinaryToPath(
+      ncUrl,
+      ncUser,
+      ncPass,
+      ["eStundnzettl", "Archiv"],
+      filename,
+      base64,
+      "application/pdf",
+    );
+    return { ok: true, target: "nextcloud" };
+  } catch (err) {
+    log.warn("Nextcloud PDF-Archiv fehlgeschlagen:", err);
+    return { ok: false, error: String(err?.message || err), target: "nextcloud" };
+  }
+}


### PR DESCRIPTION
## Kontext

Neues Feature für die **gesetzlich geforderte Langzeit-Aufbewahrung** von Stundenaufzeichnungen: Beim ersten App-Öffnen pro Tag wird automatisch ein Monats-PDF erzeugt, das alle bisherigen Tage des laufenden Monats enthält. Beim Monats-Übergang wird das Vormonat final exportiert und eine neue Datei begonnen. Damit sind die Aufzeichnungen auch ohne App (im Arbeitsgerichts-/Steuerberater-Kontext) dauerhaft lesbar.

## Summary

- 📄 **Neues Monats-PDF pro Tag** (Startup-Check + Resume-Listener), wächst Tag für Tag
- 📁 **Zwei Ziele, einzeln togglebar**: Lokaler Ordner (`Documents/eStundnzettl/Archiv/`) + Nextcloud (`/eStundnzettl/Archiv/` via WebDAV)
- ✍️ **pdfmake** statt html2pdf.js → echter **durchsuchbarer Text** (Strg+F, Screenreader, gerichts­verwertbar), A4 garantiert, ~30 KB/Monat statt 200 KB–2 MB
- ⚡ **Content-Hash-Skip**: an Tagen ohne Eintrags­änderung = null Schreibzugriffe, null Netzwerk
- 📦 **Lazy-Loading**: pdfmake (943 KB) nur im eigenen Chunk, Haupt-Bundle unberührt

## Bewusst NICHT in diesem PR: Google Drive

Der native `GoogleDriveBackupPlugin.java` verwaltet den OAuth-Scope in **einem einzigen** `lastGrantedScope`-Feld (SharedPreferences). Ein zweiter Scope (`drive.file` für sichtbare PDFs) würde den State des bestehenden JSON-Backups überschreiben — genau die Art Regression, die in früheren Versionen bereits auftrat. GDrive-PDF-Upload kommt daher in einer separaten, isoliert getesteten Iteration 2 mit sauberer State-Trennung.

**In diesem PR wird am GDrive-Code-Pfad kein einziges Zeichen geändert.**

## Architektur

### Neue Dateien
- `src/utils/pdfArchive.js` — headless pdfmake-Generator (reine Funktion, kein DOM/React). Dynamischer Import für Code-Splitting.
- `src/utils/pdfArchiveTargets.js` — Ziel-Adapter für Lokal (`@capacitor/filesystem`) und Nextcloud (WebDAV)
- `src/hooks/useAutoPdfArchive.js` — Scheduler mit Startup-Check, Resume-Listener, Monats-Übergangs-Logik, Hash-Skip
- `src/components/Settings/PdfArchiveSettings.jsx` — Neue Settings-Card mit Master-Toggle, zwei Ziel-Toggles, „Jetzt ausführen"-Button, Letzter-Lauf-Anzeige

### Geänderte Dateien (additiv, keine Regressionen)
- `src/hooks/constants.js` — neue `STORAGE_KEYS` (`PDF_ARCHIVE_*`)
- `src/App.jsx` — `useAutoPdfArchive` gemountet, State an `<Settings>` weitergereicht
- `src/components/Settings.jsx` — neue Card eingebunden
- `src/utils/nextcloudClient.js` — **additiv**: neue exports `uploadBinaryToPath` + `ensureFolderPath` + interne `nativeHttpBinary`. Bestehende `uploadBackup`, `uploadBackup`, `ensureFolder` **wort-wörtlich unverändert**.
- `android/.../NextcloudLoginFlowPlugin.java` — **additiv**: neuer optionaler `bodyBase64`-Parameter für binäre PUTs. Alle bestehenden Call-Sites (die `body` als String übergeben) laufen unverändert weiter.
- `package.json` — neue Dependency `pdfmake`

### NICHT angefasst
- `src/hooks/useAutoBackup.js`
- `src/utils/googleDriveBackup.js`
- `src/utils/googleDrive.js`
- `android/.../GoogleDriveBackupPlugin.java`
- `src/components/PrintReport.jsx` (interaktives Drucken/Teilen bleibt bei html2pdf.js)

## Datenfluss pro Lauf

```
useAutoPdfArchive.tick()
 ├─ lastRun < heute? → sonst return
 ├─ Monatswechsel? → Vormonat finalisieren
 ├─ filterEntriesForMonth(year, month)
 ├─ hashMonthContent(...) === PDF_ARCHIVE_LAST_HASH? → JA → return
 ├─ generateMonthlyPdfBlob(...) (pdfmake, ~30 KB)
 ├─ Promise.allSettled:
 │    ├─ if local:     writeLocalArchive(filename, base64)
 │    └─ if nextcloud: uploadNextcloudArchive(filename, base64)
 └─ LAST_RUN / LAST_MONTH / LAST_HASH / FAIL_COUNT (dualWrite)
```

## Test plan

- [x] `npm run lint` → 0 errors (25 pre-existing warnings in unberührtem Code)
- [x] `npm run build` → Vite-Build erfolgreich, pdfmake in eigenem Chunk (943 KB lazy)
- [x] `npm test` → **169/169 tests passing** (keine Regressionen)
- [ ] Android-Gerät: Settings → neue Card „Automatisches PDF-Archiv" sichtbar
- [ ] Master-Toggle + Lokal → „Jetzt ausführen" → `Documents/eStundnzettl/Archiv/Stundenzettel_YYYY-MM_Name.pdf` existiert, PDF-Viewer liest es, **Strg+F findet Text**
- [ ] Neuen Eintrag hinzufügen → „Jetzt ausführen" → PDF enthält den neuen Eintrag (überschrieben)
- [ ] „Jetzt ausführen" ohne Datenänderung → kein Upload (Hash-Skip), Datei-Timestamp unverändert
- [ ] Nextcloud-Toggle aktivieren → Lauf → PDF in Nextcloud-Web-UI unter `/eStundnzettl/Archiv/` sichtbar
- [ ] `PDF_ARCHIVE_LAST_RUN` in localStorage auf gestern setzen → App schließen/öffnen → automatischer Lauf
- [ ] `PDF_ARCHIVE_LAST_MONTH` auf Vormonat setzen → Lauf erzeugt zwei Dateien (Vormonat + aktueller Monat)
- [ ] **Regression**: bestehenden GDrive-JSON-Backup manuell auslösen → funktioniert unverändert

https://claude.ai/code/session_01SkaYZAd5id2sQRL6kThg35