### PR TITLE
feat(archive): GDrive-Upload fuer PDF-Archiv (Iteration 2)

### DIFF
--- a/src/components/Settings/PdfArchiveSettings.jsx
+++ b/src/components/Settings/PdfArchiveSettings.jsx
@@ -1,11 +1,16 @@
 import React, { useEffect, useState, useCallback } from "react";
-import { FileText, CheckCircle2, AlertTriangle, Loader, HardDrive, Server } from "lucide-react";
+import { FileText, CheckCircle2, AlertTriangle, Loader, HardDrive, Server, Cloud } from "lucide-react";
 import toast from "react-hot-toast";
 import { Card } from "../../utils";
 import { STORAGE_KEYS } from "../../hooks/constants";
 import { isSQLiteActive } from "../../db/storageMode";
 import { getSetting, setSetting } from "../../db/repositories/settingsRepo";
 import { logger } from "../../utils/logger";
+import {
+  connectGoogleDrivePdf,
+  disconnectGoogleDrivePdf,
+  getGoogleDrivePdfStatus,
+} from "../../utils/googleDrivePdfArchive";
 
 const log = logger.scope("PdfArchiveSettings");
 
@@ -36,6 +41,10 @@ const PdfArchiveSettings = ({ nextcloudEnabled, performRun, lastRun, lastError }
   const [enabled, setEnabled] = useState(() => readBool(STORAGE_KEYS.PDF_ARCHIVE_ENABLED));
   const [localTarget, setLocalTarget] = useState(() => readBool(STORAGE_KEYS.PDF_ARCHIVE_LOCAL));
   const [nextcloudTarget, setNextcloudTarget] = useState(() => readBool(STORAGE_KEYS.PDF_ARCHIVE_NEXTCLOUD));
+  const [gdriveTarget, setGdriveTarget] = useState(() => readBool(STORAGE_KEYS.PDF_ARCHIVE_GDRIVE));
+  const [gdriveConnected, setGdriveConnected] = useState(false);
+  const [gdriveEmail, setGdriveEmail] = useState("");
+  const [gdriveBusy, setGdriveBusy] = useState(false);
   const [isRunning, setIsRunning] = useState(false);
 
   // SQLite nachladen (analog zum bestehenden Muster)
@@ -44,17 +53,35 @@ const PdfArchiveSettings = ({ nextcloudEnabled, performRun, lastRun, lastError }
     let cancelled = false;
     (async () => {
       try {
-        const [en, loc, nc] = await Promise.all([
+        const [en, loc, nc, gd] = await Promise.all([
           getSetting("pdf_archive_enabled"),
           getSetting("pdf_archive_local"),
           getSetting("pdf_archive_nextcloud"),
+          getSetting("pdf_archive_gdrive"),
         ]);
         if (cancelled) return;
         if (en != null) setEnabled(String(en) === "true");
         if (loc != null) setLocalTarget(String(loc) === "true");
         if (nc != null) setNextcloudTarget(String(nc) === "true");
+        if (gd != null) setGdriveTarget(String(gd) === "true");
       } catch (e) {
         log.warn("SQLite-Read PDF archive settings fehlgeschlagen:", e);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  // GDrive-Archiv-Status laden (separat vom JSON-Backup-GDrive-Status)
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const status = await getGoogleDrivePdfStatus();
+        if (cancelled) return;
+        setGdriveConnected(!!(status?.connected && status?.hasToken));
+        setGdriveEmail(status?.accountEmail || "");
+      } catch (e) {
+        log.warn("GDrive-PDF-Archiv Status laden fehlgeschlagen:", e);
       }
     })();
     return () => { cancelled = true; };
@@ -87,12 +114,60 @@ const PdfArchiveSettings = ({ nextcloudEnabled, performRun, lastRun, lastError }
     await dualWrite(STORAGE_KEYS.PDF_ARCHIVE_NEXTCLOUD, "pdf_archive_nextcloud", String(next));
   }, [nextcloudTarget, nextcloudEnabled]);
 
+  const handleGdriveConnect = useCallback(async () => {
+    setGdriveBusy(true);
+    try {
+      const result = await connectGoogleDrivePdf();
+      setGdriveConnected(true);
+      setGdriveEmail(result?.email || "");
+      toast.success("Google Drive (PDF-Archiv) verbunden");
+    } catch (err) {
+      const msg = String(err?.message || err);
+      if (msg.includes("CANCELLED")) {
+        toast("Verbindung abgebrochen", { icon: "ℹ️" });
+      } else {
+        toast.error(`Verbindung fehlgeschlagen: ${msg}`);
+      }
+    } finally {
+      setGdriveBusy(false);
+    }
+  }, []);
+
+  const handleGdriveDisconnect = useCallback(async () => {
+    setGdriveBusy(true);
+    try {
+      await disconnectGoogleDrivePdf();
+      setGdriveConnected(false);
+      setGdriveEmail("");
+      // Wenn der User trennt, deaktiviere auch den Ziel-Toggle
+      if (gdriveTarget) {
+        setGdriveTarget(false);
+        await dualWrite(STORAGE_KEYS.PDF_ARCHIVE_GDRIVE, "pdf_archive_gdrive", "false");
+      }
+      toast.success("Google Drive (PDF-Archiv) getrennt");
+    } catch (err) {
+      toast.error(`Trennen fehlgeschlagen: ${err?.message || err}`);
+    } finally {
+      setGdriveBusy(false);
+    }
+  }, [gdriveTarget]);
+
+  const toggleGdrive = useCallback(async () => {
+    if (!gdriveConnected) {
+      toast.error("Bitte zuerst mit Google Drive verbinden.");
+      return;
+    }
+    const next = !gdriveTarget;
+    setGdriveTarget(next);
+    await dualWrite(STORAGE_KEYS.PDF_ARCHIVE_GDRIVE, "pdf_archive_gdrive", String(next));
+  }, [gdriveTarget, gdriveConnected]);
+
   const handleRunNow = useCallback(async () => {
     if (!enabled) {
       toast.error("PDF-Archiv ist deaktiviert.");
       return;
     }
-    if (!localTarget && !nextcloudTarget) {
+    if (!localTarget && !nextcloudTarget && !gdriveTarget) {
       toast.error("Bitte mindestens ein Ziel auswaehlen.");
       return;
     }
@@ -118,7 +193,7 @@ const PdfArchiveSettings = ({ nextcloudEnabled, performRun, lastRun, lastError }
     } finally {
       setIsRunning(false);
     }
-  }, [enabled, localTarget, nextcloudTarget, performRun]);
+  }, [enabled, localTarget, nextcloudTarget, gdriveTarget, performRun]);
 
   return (
     <Card className="p-4">
@@ -197,22 +272,61 @@ const PdfArchiveSettings = ({ nextcloudEnabled, performRun, lastRun, lastError }
             </label>
           </div>
 
-          {/* Google Drive — Platzhalter fuer Iteration 2 */}
-          <div className="flex items-center justify-between bg-zinc-50 dark:bg-zinc-900/30 p-3 rounded-xl border border-dashed border-zinc-300 dark:border-zinc-700">
+          {/* Google Drive (drive.file, sichtbarer Ordner eStundnzettl Archiv) */}
+          <div className="flex items-center justify-between bg-zinc-100 dark:bg-zinc-700 p-3 rounded-xl">
             <div className="flex items-center gap-3">
-              <div className="p-2 rounded-full bg-zinc-200 dark:bg-zinc-700 text-zinc-400">
-                <FileText size={18} />
+              <div className={`p-2 rounded-full ${gdriveTarget && gdriveConnected ? "bg-green-100 text-green-600" : "bg-zinc-200 text-zinc-400"}`}>
+                <Cloud size={18} />
               </div>
               <div>
-                <span className="block font-bold text-sm text-zinc-500 dark:text-zinc-400">
-                  Google Drive
-                </span>
-                <span className="block text-xs text-zinc-400">
-                  Folgt in einem separaten Update (isoliert getestet)
+                <div className="flex items-center gap-2">
+                  <span className="block font-bold text-sm text-zinc-800 dark:text-white">
+                    Google Drive
+                  </span>
+                  {gdriveConnected && (
+                    <span className="flex items-center px-1.5 py-0.5 bg-green-100 dark:bg-green-900/40 text-green-600 dark:text-green-400 text-[10px] font-bold rounded-full">
+                      Verbunden
+                    </span>
+                  )}
+                </div>
+                <span className="block text-xs text-zinc-500 dark:text-zinc-400">
+                  {gdriveConnected
+                    ? (gdriveEmail
+                        ? `Ordner eStundnzettl Archiv · ${gdriveEmail}`
+                        : "Ordner eStundnzettl Archiv")
+                    : "Separater Zugriff vom JSON-Backup (drive.file-Scope)"}
                 </span>
               </div>
             </div>
-            <span className="text-[10px] font-bold text-zinc-400 uppercase">bald</span>
+            {gdriveConnected ? (
+              <div className="flex items-center gap-2">
+                <label className="relative inline-flex items-center cursor-pointer">
+                  <input
+                    type="checkbox"
+                    className="sr-only peer"
+                    checked={gdriveTarget}
+                    onChange={toggleGdrive}
+                  />
+                  <div className="w-11 h-6 bg-zinc-200 dark:bg-zinc-600 peer-checked:bg-indigo-500 rounded-full peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all" />
+                </label>
+                <button
+                  onClick={handleGdriveDisconnect}
+                  disabled={gdriveBusy}
+                  className="px-2 py-1 text-[10px] font-bold rounded border border-red-200 bg-red-50 text-red-600 dark:bg-red-900/20 dark:text-red-300 dark:border-red-800 disabled:opacity-50"
+                >
+                  {gdriveBusy ? <Loader size={10} className="animate-spin" /> : "Trennen"}
+                </button>
+              </div>
+            ) : (
+              <button
+                onClick={handleGdriveConnect}
+                disabled={gdriveBusy}
+                className="px-3 py-1.5 text-xs font-bold rounded-lg border border-zinc-300 bg-white text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200 dark:border-zinc-600 disabled:opacity-50 flex items-center gap-1.5"
+              >
+                {gdriveBusy ? <Loader size={12} className="animate-spin" /> : <Cloud size={12} />}
+                Verbinden
+              </button>
+            )}
           </div>
 
           {/* Info-Zeile */}

--- a/src/hooks/constants.js
+++ b/src/hooks/constants.js
@@ -54,6 +54,7 @@ export const STORAGE_KEYS = {
   PDF_ARCHIVE_ENABLED: "estundnzettl_pdf_archive_enabled",
   PDF_ARCHIVE_LOCAL: "estundnzettl_pdf_archive_local",
   PDF_ARCHIVE_NEXTCLOUD: "estundnzettl_pdf_archive_nextcloud",
+  PDF_ARCHIVE_GDRIVE: "estundnzettl_pdf_archive_gdrive",
   PDF_ARCHIVE_LAST_RUN: "estundnzettl_pdf_archive_last_run",
   PDF_ARCHIVE_LAST_MONTH: "estundnzettl_pdf_archive_last_month",
   PDF_ARCHIVE_LAST_HASH: "estundnzettl_pdf_archive_last_hash",

--- a/src/hooks/useAutoPdfArchive.js
+++ b/src/hooks/useAutoPdfArchive.js
@@ -26,7 +26,7 @@ import {
   buildArchiveFilename,
 } from "../utils/pdfArchive";
 import { blobToBase64 } from "../utils";
-import { writeLocalArchive, uploadNextcloudArchive } from "../utils/pdfArchiveTargets";
+import { writeLocalArchive, uploadNextcloudArchive, uploadGDriveArchive } from "../utils/pdfArchiveTargets";
 
 const log = logger.scope("PdfArchive");
 
@@ -91,6 +91,9 @@ async function runForMonth({ entries, userData, workCodes, year, month, targets 
   if (targets.nextcloud) {
     results.push(await uploadNextcloudArchive(filename, base64));
   }
+  if (targets.gdrive) {
+    results.push(await uploadGDriveArchive(filename, blob));
+  }
 
   const anyOk = results.some((r) => r.ok);
   const errors = results.filter((r) => !r.ok);
@@ -122,8 +125,9 @@ export function useAutoPdfArchive(entries, userData, workCodes) {
     const targets = {
       local: localStorage.getItem(STORAGE_KEYS.PDF_ARCHIVE_LOCAL) === "true",
       nextcloud: localStorage.getItem(STORAGE_KEYS.PDF_ARCHIVE_NEXTCLOUD) === "true",
+      gdrive: localStorage.getItem(STORAGE_KEYS.PDF_ARCHIVE_GDRIVE) === "true",
     };
-    if (!targets.local && !targets.nextcloud) return null;
+    if (!targets.local && !targets.nextcloud && !targets.gdrive) return null;
     return targets;
   };
 

--- a/src/utils/googleDrivePdfArchive.js
+++ b/src/utils/googleDrivePdfArchive.js
@@ -1,0 +1,418 @@
+/**
+ * googleDrivePdfArchive.js — Parallel GDrive-Integration fuer das automatische
+ * PDF-Archiv (Iteration 2).
+ *
+ * DESIGN-LEITLINIE: Diese Datei ist **komplett isoliert** vom bestehenden
+ * `googleDriveBackup.js` (JSON-Backup in appDataFolder). Die beiden Module
+ * teilen sich nur den Capacitor-Plugin-Endpunkt `GoogleDriveBackup`, aber
+ * jedes uebergibt seinen eigenen Scope bei JEDEM Aufruf, hat einen eigenen
+ * Session-Token-Cache, einen eigenen localStorage-Key und eigenes Folder-ID-
+ * Caching. Google's Identity AuthorizationClient unterstuetzt Incremental
+ * Authorization → beide Scopes koennen am selben Account parallel existieren.
+ *
+ * Warum kein Eingriff in googleDriveBackup.js?
+ * - `sessionAccessToken` dort ist ein Modul-Level-Cache ohne Scope-Key.
+ *   Wuerden wir ihn mitbenutzen, koennte ein drive.file-Token in einem
+ *   appdata-Call landen (oder umgekehrt) → 403/Bruch des JSON-Backups.
+ * - `TOKEN_STORAGE_KEY = 'google_auth_state'` ist ebenfalls ein einziger
+ *   Schluessel und traegt `scope` statisch eingetragen.
+ *
+ * Unabhaengigkeit → null Regressionsrisiko fuer den JSON-Backup-Flow.
+ */
+
+import { registerPlugin } from '@capacitor/core';
+
+// ─────── Konstanten (alle eigen, keine Ueberlappung mit googleDriveBackup.js) ───────
+
+const AUTH_SCOPE_PDF = 'https://www.googleapis.com/auth/drive.file';
+const TOKEN_STORAGE_KEY_PDF = 'google_auth_state_pdf';
+const FOLDER_ID_STORAGE_KEY = 'google_pdf_archive_folder_id';
+const ARCHIVE_FOLDER_NAME = 'eStundnzettl Archiv';
+const SESSION_TOKEN_MAX_AGE_MS = 45 * 60 * 1000;
+
+const GoogleDriveBackupPlugin = registerPlugin('GoogleDriveBackup');
+
+// ─────── Modul-lokaler Token-Cache (isoliert!) ───────
+
+let sessionAccessTokenPdf = null;
+let sessionTokenSavedAtPdf = 0;
+
+const cacheSessionTokenPdf = (token) => {
+  sessionAccessTokenPdf = token || null;
+  sessionTokenSavedAtPdf = token ? Date.now() : 0;
+};
+
+const getCachedSessionTokenPdf = () => {
+  if (!sessionAccessTokenPdf) return null;
+  if (Date.now() - sessionTokenSavedAtPdf > SESSION_TOKEN_MAX_AGE_MS) {
+    cacheSessionTokenPdf(null);
+    return null;
+  }
+  return sessionAccessTokenPdf;
+};
+
+// ─────── Persistenter Auth-State (separater localStorage-Key) ───────
+
+const getStoredAuthPdf = () => {
+  try {
+    const raw = localStorage.getItem(TOKEN_STORAGE_KEY_PDF);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+};
+
+const saveStoredAuthPdf = (auth) => {
+  localStorage.setItem(
+    TOKEN_STORAGE_KEY_PDF,
+    JSON.stringify({
+      scope: AUTH_SCOPE_PDF,
+      savedAt: Date.now(),
+      source: auth?.source || 'native-plugin',
+      accountEmail: auth?.accountEmail || null,
+      nativeConnected: auth?.nativeConnected !== false,
+      reauthRequired: !!auth?.reauthRequired,
+    }),
+  );
+};
+
+const clearStoredAuthPdf = () => {
+  localStorage.removeItem(TOKEN_STORAGE_KEY_PDF);
+  localStorage.removeItem(FOLDER_ID_STORAGE_KEY);
+  cacheSessionTokenPdf(null);
+};
+
+// ─────── Plugin-Verfuegbarkeit ───────
+
+const nativeAvailable = async () => {
+  try {
+    return typeof GoogleDriveBackupPlugin?.getStatus === 'function';
+  } catch {
+    return false;
+  }
+};
+
+const parseNativeError = (error, fallback = 'GOOGLE_DRIVE_PDF_ERROR') => {
+  const message = String(error?.message || error || fallback);
+  if (message.includes('not implemented') || message.includes('UNAVAILABLE')) {
+    return 'GOOGLE_DRIVE_NATIVE_UNAVAILABLE';
+  }
+  if (message.includes('CANCELLED')) {
+    return 'GOOGLE_DRIVE_AUTH_CANCELLED';
+  }
+  return message;
+};
+
+// ─────── Auth-Operationen (immer explizit mit scope: AUTH_SCOPE_PDF) ───────
+
+/**
+ * Oeffnet den Consent-Flow fuer den drive.file-Scope. Falls der Nutzer bereits
+ * den drive.appdata-Scope (JSON-Backup) am selben Google-Account genehmigt hat,
+ * wird Google den drive.file-Scope in der Regel **inkrementell** ohne erneuten
+ * Consent hinzufuegen. Andernfalls erscheint ein Consent-Dialog.
+ */
+export async function connectGoogleDrivePdf() {
+  if (!(await nativeAvailable())) {
+    throw new Error('GOOGLE_DRIVE_NATIVE_UNAVAILABLE');
+  }
+  try {
+    const nativeResult = await GoogleDriveBackupPlugin.connect({ scope: AUTH_SCOPE_PDF });
+    const accessToken = nativeResult?.accessToken || null;
+    if (!accessToken) {
+      throw new Error('GOOGLE_DRIVE_PDF_AUTH_NO_ACCESS_TOKEN');
+    }
+    cacheSessionTokenPdf(accessToken);
+    saveStoredAuthPdf({
+      accountEmail: nativeResult?.accountEmail || null,
+      source: nativeResult?.source || 'native-plugin',
+      nativeConnected: true,
+      reauthRequired: false,
+    });
+    return {
+      authentication: { accessToken },
+      email: nativeResult?.accountEmail || null,
+      native: nativeResult || null,
+    };
+  } catch (error) {
+    clearStoredAuthPdf();
+    throw new Error(parseNativeError(error));
+  }
+}
+
+/**
+ * Widerruft NUR den drive.file-Scope. Der drive.appdata-Scope des bestehenden
+ * JSON-Backups bleibt unangetastet (eigener Revocation-Call vom anderen Modul).
+ *
+ * Achtung: Der native Plugin ruft `revokeAccess` auf dem Scope auf, der aktuell
+ * in `lastGrantedScope` steht. Deshalb muessen wir VOR dem Disconnect-Call
+ * einen Status-Call mit drive.file machen, damit das Plugin seinen
+ * `lastGrantedScope` auf drive.file setzt. Erst dann `disconnect()` aufrufen.
+ */
+export async function disconnectGoogleDrivePdf() {
+  clearStoredAuthPdf();
+
+  if (!(await nativeAvailable())) return;
+
+  try {
+    // Plugin's lastGrantedScope auf drive.file setzen, damit disconnect()
+    // nur diesen Scope revoked. getStatus({scope: AUTH_SCOPE_PDF}) setzt
+    // lastGrantedScope im Plugin entsprechend.
+    await GoogleDriveBackupPlugin.getStatus({ scope: AUTH_SCOPE_PDF });
+    await GoogleDriveBackupPlugin.disconnect();
+  } catch {
+    // Lokaler State ist bereits geleert — Native-Fehler ignorieren
+  }
+}
+
+/**
+ * Holt einen gueltigen drive.file-Token, entweder aus dem Session-Cache oder
+ * per silent refresh ueber den Plugin. Immer mit explizitem scope.
+ */
+export async function getValidGoogleTokenPdf() {
+  const cached = getCachedSessionTokenPdf();
+  if (cached) return { accessToken: cached };
+
+  if (!(await nativeAvailable())) {
+    clearStoredAuthPdf();
+    throw new Error('AUTH_REQUIRED');
+  }
+
+  try {
+    const nativeResult = await GoogleDriveBackupPlugin.refreshToken({ scope: AUTH_SCOPE_PDF });
+    const accessToken = nativeResult?.accessToken || null;
+    if (!accessToken) {
+      throw new Error('AUTH_REQUIRED');
+    }
+    cacheSessionTokenPdf(accessToken);
+    saveStoredAuthPdf({
+      accountEmail: nativeResult?.accountEmail || null,
+      source: nativeResult?.source || 'native-plugin',
+      nativeConnected: true,
+      reauthRequired: false,
+    });
+    return { accessToken };
+  } catch (error) {
+    const message = parseNativeError(error, 'AUTH_REQUIRED');
+    const stored = getStoredAuthPdf();
+    const requiresReauth = message.includes('AUTH_REQUIRED');
+    saveStoredAuthPdf({
+      accountEmail: stored?.accountEmail || null,
+      source: stored?.source || 'native-plugin',
+      nativeConnected: true,
+      reauthRequired: requiresReauth,
+    });
+    cacheSessionTokenPdf(null);
+    throw new Error(requiresReauth ? 'AUTH_REQUIRED' : message);
+  }
+}
+
+/**
+ * Status-Info fuer die Settings-UI. Kombiniert persistenten State und
+ * plugin-seitigen Status, aber wieder: IMMER mit explizitem scope.
+ */
+export async function getGoogleDrivePdfStatus() {
+  const stored = getStoredAuthPdf();
+  if (!(await nativeAvailable())) {
+    return {
+      available: false,
+      connected: false,
+      hasToken: false,
+      reauthRequired: false,
+      scope: AUTH_SCOPE_PDF,
+      accountEmail: stored?.accountEmail || null,
+    };
+  }
+  try {
+    const result = await GoogleDriveBackupPlugin.getStatus({ scope: AUTH_SCOPE_PDF });
+    return {
+      available: true,
+      connected: !!result?.connected && !!stored?.nativeConnected,
+      hasToken: !!result?.hasToken && !!stored?.nativeConnected,
+      reauthRequired: !!result?.reauthRequired,
+      scope: AUTH_SCOPE_PDF,
+      accountEmail: result?.accountEmail || stored?.accountEmail || null,
+    };
+  } catch (error) {
+    return {
+      available: true,
+      connected: !!stored?.nativeConnected,
+      hasToken: false,
+      reauthRequired: false,
+      scope: AUTH_SCOPE_PDF,
+      accountEmail: stored?.accountEmail || null,
+      error: parseNativeError(error),
+    };
+  }
+}
+
+// ─────── authFetch mit eigenem Retry-Pfad ───────
+
+async function authFetchPdf(url, options = {}) {
+  const execute = async (accessToken) =>
+    fetch(url, {
+      ...options,
+      headers: {
+        ...(options.headers || {}),
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+  const auth = await getValidGoogleTokenPdf();
+  if (!auth?.accessToken) throw new Error('AUTH_REQUIRED');
+
+  let response = await execute(auth.accessToken);
+
+  if (response.status === 401 || response.status === 403) {
+    cacheSessionTokenPdf(null);
+    const refreshed = await getValidGoogleTokenPdf();
+    if (!refreshed?.accessToken) throw new Error('AUTH_REQUIRED');
+    response = await execute(refreshed.accessToken);
+    if (response.status === 401 || response.status === 403) {
+      throw new Error('AUTH_REQUIRED');
+    }
+  }
+
+  return response;
+}
+
+// ─────── Folder-Management (sichtbarer Ordner im Drive-Root) ───────
+
+/**
+ * Findet oder erstellt den Ordner `eStundnzettl Archiv` im Drive des Nutzers.
+ *
+ * Wichtig: Mit dem drive.file-Scope sieht die App NUR Dateien/Ordner, die sie
+ * selbst erstellt hat. Die Suche liefert also nur dann Treffer, wenn wir den
+ * Ordner bei einem frueheren Lauf bereits erstellt haben. Wenn der Nutzer ihn
+ * manuell loescht, liefert die Suche nichts → wir erstellen einen neuen.
+ */
+async function findOrCreateArchiveFolder() {
+  // Cache-Hit: ID aus localStorage
+  const cached = localStorage.getItem(FOLDER_ID_STORAGE_KEY);
+  if (cached) {
+    // Cheap verify: get file metadata — falls 404, Cache invalidieren
+    try {
+      const verifyRes = await authFetchPdf(
+        `https://www.googleapis.com/drive/v3/files/${cached}?fields=id,name,trashed`,
+        { method: 'GET' },
+      );
+      if (verifyRes.ok) {
+        const data = await verifyRes.json();
+        if (data?.id && !data.trashed) {
+          return cached;
+        }
+      }
+      // 404 / trashed → invalidiere Cache, fall through zur Neu-Erstellung
+      localStorage.removeItem(FOLDER_ID_STORAGE_KEY);
+    } catch {
+      localStorage.removeItem(FOLDER_ID_STORAGE_KEY);
+    }
+  }
+
+  // Suche nach vorhandenem Ordner
+  const query = `name = '${ARCHIVE_FOLDER_NAME}' and mimeType = 'application/vnd.google-apps.folder' and trashed = false`;
+  const searchUrl = `https://www.googleapis.com/drive/v3/files?q=${encodeURIComponent(query)}&fields=files(id,name)&pageSize=1`;
+  const searchRes = await authFetchPdf(searchUrl, { method: 'GET' });
+  if (searchRes.ok) {
+    const data = await searchRes.json();
+    const existing = data?.files?.[0]?.id;
+    if (existing) {
+      localStorage.setItem(FOLDER_ID_STORAGE_KEY, existing);
+      return existing;
+    }
+  }
+
+  // Ordner erstellen
+  const createRes = await authFetchPdf('https://www.googleapis.com/drive/v3/files', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name: ARCHIVE_FOLDER_NAME,
+      mimeType: 'application/vnd.google-apps.folder',
+    }),
+  });
+
+  if (!createRes.ok) {
+    const txt = await createRes.text();
+    throw new Error(`Folder create failed: ${createRes.status} ${txt}`);
+  }
+
+  const created = await createRes.json();
+  if (!created?.id) {
+    throw new Error('Folder create returned no id');
+  }
+  localStorage.setItem(FOLDER_ID_STORAGE_KEY, created.id);
+  return created.id;
+}
+
+// ─────── Datei-Upload (Multipart mit binaerem Blob) ───────
+
+/**
+ * Findet die Datei-ID im Archiv-Ordner nach Dateiname (fuer Update statt Create).
+ */
+async function findFileIdInFolder(fileName, folderId) {
+  const query = `name = '${fileName.replace(/'/g, "\\'")}' and '${folderId}' in parents and trashed = false`;
+  const url = `https://www.googleapis.com/drive/v3/files?q=${encodeURIComponent(query)}&fields=files(id,name)&pageSize=1`;
+  const res = await authFetchPdf(url, { method: 'GET' });
+  if (!res.ok) return null;
+  const data = await res.json();
+  return data?.files?.[0]?.id || null;
+}
+
+/**
+ * Laedt ein PDF in den `eStundnzettl Archiv`-Ordner hoch. Existiert bereits
+ * eine Datei mit gleichem Namen → Update (PATCH); sonst → neu erstellen (POST).
+ *
+ * @param {string} filename   z.B. 'Stundenzettel_2026-04_Max.pdf'
+ * @param {Blob}   blob       PDF-Blob (aus pdfmake.createPdf().getBlob())
+ */
+export async function uploadPdfArchiveFile(filename, blob) {
+  const folderId = await findOrCreateArchiveFolder();
+  const existingId = await findFileIdInFolder(filename, folderId);
+
+  const boundary = `-------pdf_archive_${Date.now()}`;
+  const metadata = existingId
+    ? { name: filename, mimeType: 'application/pdf' }
+    : { name: filename, mimeType: 'application/pdf', parents: [folderId] };
+
+  // Multipart/related Body aus Text-Parts + binaerem Blob zusammensetzen.
+  // new Blob([...]) akzeptiert eine Mischung aus Strings und Blobs und
+  // behaelt die Binaerdaten byte-genau bei.
+  const bodyBlob = new Blob(
+    [
+      `--${boundary}\r\n`,
+      'Content-Type: application/json; charset=UTF-8\r\n\r\n',
+      JSON.stringify(metadata),
+      `\r\n--${boundary}\r\n`,
+      'Content-Type: application/pdf\r\n\r\n',
+      blob,
+      `\r\n--${boundary}--`,
+    ],
+  );
+
+  const url = existingId
+    ? `https://www.googleapis.com/upload/drive/v3/files/${existingId}?uploadType=multipart`
+    : 'https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart';
+
+  const response = await authFetchPdf(url, {
+    method: existingId ? 'PATCH' : 'POST',
+    headers: {
+      'Content-Type': `multipart/related; boundary=${boundary}`,
+    },
+    body: bodyBlob,
+  });
+
+  if (!response.ok) {
+    const txt = await response.text();
+    // 404 auf den Ordner → Cache invalidieren und beim naechsten Aufruf
+    // neu erstellen
+    if (response.status === 404) {
+      localStorage.removeItem(FOLDER_ID_STORAGE_KEY);
+    }
+    throw new Error(`PDF upload failed: ${response.status} ${txt}`);
+  }
+
+  return response.json();
+}
+
+// Re-exports fuer Settings-UI und Targets
+export { AUTH_SCOPE_PDF, TOKEN_STORAGE_KEY_PDF, FOLDER_ID_STORAGE_KEY, getStoredAuthPdf };

--- a/src/utils/pdfArchiveTargets.js
+++ b/src/utils/pdfArchiveTargets.js
@@ -10,6 +10,7 @@
 import { Filesystem, Directory } from "@capacitor/filesystem";
 import { Capacitor } from "@capacitor/core";
 import { uploadBinaryToPath } from "./nextcloudClient";
+import { uploadPdfArchiveFile } from "./googleDrivePdfArchive";
 import { deobfuscate } from "./obfuscate";
 import { STORAGE_KEYS } from "../hooks/constants";
 import { logger } from "./logger";
@@ -76,5 +77,25 @@ export async function uploadNextcloudArchive(filename, base64) {
   } catch (err) {
     log.warn("Nextcloud PDF-Archiv fehlgeschlagen:", err);
     return { ok: false, error: String(err?.message || err), target: "nextcloud" };
+  }
+}
+
+/**
+ * Laedt das PDF in den sichtbaren Google-Drive-Ordner `eStundnzettl Archiv`
+ * hoch. Nutzt eine komplett eigene Auth-/Token-Pipeline
+ * (`googleDrivePdfArchive.js`), die den bestehenden JSON-Backup-Flow
+ * (`googleDriveBackup.js`) nicht beruehrt — eigener Scope (drive.file),
+ * eigener Session-Token-Cache, eigener localStorage-Auth-State.
+ */
+export async function uploadGDriveArchive(filename, blob) {
+  if (!blob) {
+    return { ok: false, error: "Kein Blob fuer GDrive-Upload", target: "gdrive" };
+  }
+  try {
+    await uploadPdfArchiveFile(filename, blob);
+    return { ok: true, target: "gdrive" };
+  } catch (err) {
+    log.warn("GDrive PDF-Archiv fehlgeschlagen:", err);
+    return { ok: false, error: String(err?.message || err), target: "gdrive" };
   }
 }


### PR DESCRIPTION
## Kontext

Iteration 2 des automatischen PDF-Archivs: **Google Drive als drittes Ablage-Ziel**. Das Monats-PDF wird in einen sichtbaren Ordner `eStundnzettl Archiv` im normalen Google Drive des Nutzers hochgeladen — damit ist die Langzeit-Aufbewahrung auch in GDrive ohne App lesbar (durchsuchbar, teilbar, herunterladbar über drive.google.com).

In Iteration 1 (D3rPaPaH0d3n/eStundnzettl#5) wurde GDrive bewusst ausgeklammert, weil der ursprüngliche Plan befürchtete, dass eine Plugin-Änderung nötig sei und den bestehenden JSON-Backup-Flow gefährden könnte. Bei der erneuten, genauen Analyse stellt sich heraus: **keine Plugin-Änderung nötig**, wenn man den JS-Code komplett isoliert hält.

## Kern-Erkenntnis aus der Analyse

1. **Der native `GoogleDriveBackupPlugin.java` akzeptiert bei jedem Call den `scope` als Parameter** (`connect`, `getStatus`, `refreshToken`) und liefert einen frischen, scope-spezifischen Token zurück. Das Feld `lastAccessToken` wird plugin-intern nur für den Revoke-Flow genutzt.
2. **Google's `Identity AuthorizationClient` unterstützt Incremental Authorization** — zwei Scopes können am selben Account parallel existieren, ohne sich gegenseitig zu beeinflussen.
3. **Das echte Regressions-Risiko liegt in `googleDriveBackup.js`**: dort wird `sessionAccessToken` auf Modul-Ebene **ohne Scope-Key** gecached. Ein Shared-Cache-Ansatz hätte beim nächsten JSON-Backup potentiell einen `drive.file`-Token gegen die appdata-Endpoints geworfen → 403 und Bruch des JSON-Backup-Flows.

→ **Lösung**: Ein komplett paralleles JS-Modul mit eigenem Scope, eigenem Token-Cache, eigenem localStorage-Key. **Kein einziges Zeichen** am bestehenden GDrive-Code geändert.

## Summary

- 📁 Neues Modul **`src/utils/googleDrivePdfArchive.js`** (~330 Zeilen) — komplett eigenständige Auth-Pipeline für `drive.file`-Scope
- 🔒 **Isolation**: eigener `sessionAccessTokenPdf`-Cache (45 min TTL), eigener `google_auth_state_pdf` localStorage-Key, eigener Folder-ID-Cache
- 📂 **Sichtbarer Ordner**: findet/erstellt `eStundnzettl Archiv` im Drive-Root, mit verify-via-GET und Cache-Invalidierung bei 404/trashed
- 📄 **Multipart-Upload mit echtem Binary**: `new Blob([text, text, blob, text])` bewahrt die PDF-Bytes byte-genau, ohne Base64-Overhead
- ♻️ **Update statt Create**: gleicher Dateiname im Ordner → PATCH (überschreibt die Monats-Datei, wie bei Lokal/Nextcloud)
- 🛡️ **Disconnect-Safety**: vor plugin-seitigem `disconnect()` wird erst ein `getStatus({scope: drive.file})` gerufen, damit der Revoke nur den PDF-Archiv-Scope trifft und den JSON-Backup-Scope unangetastet lässt
- 🎨 **UI**: "coming soon"-Platzhalter durch echte Card mit separatem Connect/Disconnect-Flow, Email-Badge, Ziel-Toggle ersetzt

## NICHT angefasst

- `src/utils/googleDriveBackup.js`
- `src/utils/googleDrive.js`
- `src/hooks/useAutoBackup.js`
- `android/app/src/main/java/com/eStundnzettl/app/GoogleDriveBackupPlugin.java`

Der bestehende JSON-Backup-Flow ist byte-identisch.

## Geänderte Dateien

| Datei | Art |
|---|---|
| `src/utils/googleDrivePdfArchive.js` | **neu** (~330 Z.) |
| `src/components/Settings/PdfArchiveSettings.jsx` | geändert (Platzhalter → echte Card) |
| `src/utils/pdfArchiveTargets.js` | geändert (neue `uploadGDriveArchive`) |
| `src/hooks/useAutoPdfArchive.js` | geändert (`gdrive` in Targets + Run-Loop) |
| `src/hooks/constants.js` | geändert (`PDF_ARCHIVE_GDRIVE` Storage-Key) |

## Test plan

- [x] `npm run lint` → **0 errors** (25 pre-existing warnings in unberührtem Code)
- [x] `npm run build` → Vite-Build erfolgreich, Main-Bundle +5 KB, Settings-Chunk +2.5 KB, pdf-libs unverändert
- [x] `npm test` → **169/169 tests passing**
- [ ] Android: Settings → PDF-Archiv-Card → "Google Drive" Zeile sichtbar
- [ ] "Verbinden" tippen → Consent-Screen (wenn noch nie drive.file gewährt) oder silent incremental auth → Email-Badge erscheint
- [ ] Ziel-Toggle aktivieren → "Jetzt ausführen" → `eStundnzettl Archiv`-Ordner erscheint in drive.google.com mit der Monats-PDF, durchsuchbar
- [ ] Erneut ausführen ohne Datenänderung → Hash-Skip, keine neue Version im Drive
- [ ] Datei in Drive manuell ändern, erneut ausführen → überschrieben (PATCH)
- [ ] Ordner in Drive manuell löschen, erneut ausführen → neuer Ordner wird automatisch erstellt
- [ ] "Trennen" → nächste JSON-Backup-Aktion läuft weiterhin normal (Regression-Test für den isolierten Scope-Revoke)
- [ ] **Regression GDrive JSON-Backup**: bestehenden JSON-Backup-Flow manuell auslösen → muss unverändert funktionieren

https://claude.ai/code/session_01SkaYZAd5id2sQRL6kThg35