### PR TITLE
fix(archive): pdfmake 0.3.x Promise-API — generateMonthlyPdfBlob hing 30s

### DIFF
--- a/src/hooks/useAutoPdfArchive.js
+++ b/src/hooks/useAutoPdfArchive.js
@@ -221,6 +221,10 @@ export function useAutoPdfArchive(entries, userData, workCodes) {
   // Startup-Check (einmalig beim Mount, verzoegert damit DB-/Settings-Loads
   // abgeschlossen sind)
   useEffect(() => {
+    // Selbstheilung: falls ein frueherer Lauf durch einen Hang (z.B. alte
+    // Buggy-Version der PDF-Generierung) den Running-Flag blockiert hat,
+    // hier explizit zuruecksetzen. Kostet nichts, schuetzt vor stuck state.
+    isRunning.current = false;
     const timer = setTimeout(() => {
       performRun({ source: "startup" });
     }, 3000);

--- a/src/utils/pdfArchive.js
+++ b/src/utils/pdfArchive.js
@@ -337,35 +337,37 @@ async function getPdfMake() {
 /**
  * Erzeugt das Monats-PDF als Blob. Reine Funktion — kein DOM, kein React.
  *
- * Hard-Timeout von 30 s, damit ein potentiell hangender getBlob-Callback
- * (z.B. durch fehlende VFS-Fonts) nicht die UI dauerhaft blockiert.
+ * WICHTIG: pdfmake 0.3.x hat die API von Callback auf Promise umgestellt
+ * (CHANGELOG: "All methods return promise instead of using callback"). Der
+ * vorherige Callback-Stil `.getBlob((blob) => ...)` wird in 0.3.x still
+ * verworfen → der Callback feuert nie → der Aufrufer hing 30 s. Daher
+ * hier die aktuelle Promise-API verwenden.
+ *
+ * Safety-Timeout via Promise.race: wenn die pdfmake-Promise-Chain wider
+ * Erwarten haengen sollte, bekommt der Aufrufer nach 30 s eine klare
+ * Fehlermeldung statt eines dauerhaft blockierten UI-Zustands.
  */
 export async function generateMonthlyPdfBlob({ year, month, entries, userData, workCodes }) {
   if (!year || !month) throw new Error("generateMonthlyPdfBlob: year/month fehlen");
   const pdfMake = await getPdfMake();
   const docDefinition = buildDocDefinition({ year, month, entries, userData, workCodes });
-  return new Promise((resolve, reject) => {
-    let settled = false;
-    const timer = setTimeout(() => {
-      if (!settled) {
-        settled = true;
-        reject(new Error("PDF-Generierung Timeout (30s) — vermutlich fehlen VFS-Fonts"));
-      }
-    }, 30000);
-    try {
-      pdfMake.createPdf(docDefinition).getBlob((blob) => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        resolve(blob);
-      });
-    } catch (err) {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      reject(err);
-    }
+
+  // pdfmake 0.3.x: .getBlob() gibt direkt ein Promise<Blob> zurueck.
+  const blobPromise = pdfMake.createPdf(docDefinition).getBlob();
+
+  let timeoutHandle;
+  const timeoutPromise = new Promise((_, reject) => {
+    timeoutHandle = setTimeout(
+      () => reject(new Error("PDF-Generierung Timeout (30s)")),
+      30000,
+    );
   });
+
+  try {
+    return await Promise.race([blobPromise, timeoutPromise]);
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
 }
 
 // Re-exports fuer Tests


### PR DESCRIPTION
## Problem

Nach Hotfix #1 (PR #7, VFS-Registration) **hängt das PDF-Archiv immer noch**: jeder Tap auf „Jetzt ausführen" liefert `already-running`, und es werden keine PDFs erzeugt.

## Root Cause

**pdfmake 0.3.x hat die `.getBlob()`-API von Callback auf Promise umgestellt** (CHANGELOG: *"All methods return promise instead of using callback"*). Der vorherige Callback-Stil
```js
pdfMake.createPdf(doc).getBlob((blob) => resolve(blob))
```
wird in 0.3.x **still verworfen**: der Callback ist kein registrierter Completion-Handler mehr, sondern ein stumpfer Argument-Wert an eine parameterlose Methode — das zurückgegebene Promise wird nie awaited.

Folge:
1. App-Start → `useAutoPdfArchive` startet nach 3 s einen Lauf
2. `performRun` setzt `isRunning.current = true`, ruft `generateMonthlyPdfBlob`
3. Callback feuert nie → 30 s Hang → Timeout-Reject (aus Hotfix #1)
4. User tippt in diesen 30 s „Jetzt ausführen" → `already-running`
5. Nach 30 s Reset, aber nächster Tap startet sofort wieder 30 s Hang

Die VFS-Registration aus Hotfix #1 war korrekt implementiert, aber **allein nicht ausreichend** — das Problem lag eine Etage tiefer in der API-Nutzung selbst.

## Fix

### `src/utils/pdfArchive.js`
Umstellung auf die pdfmake 0.3.x Promise-API:
```js
const blobPromise = pdfMake.createPdf(docDefinition).getBlob();
const timeoutPromise = new Promise((_, reject) => {
  timeoutHandle = setTimeout(() => reject(new Error("PDF-Generierung Timeout (30s)")), 30000);
});
try {
  return await Promise.race([blobPromise, timeoutPromise]);
} finally {
  clearTimeout(timeoutHandle);
}
```
Schlanker, deterministisch, nutzt die offizielle neue API. Der 30-s-Safety-Timeout bleibt als Netz drin, falls je wieder was hängt.

### `src/hooks/useAutoPdfArchive.js`
Selbstheilungs-Zeile im Startup-Effect:
```js
useEffect(() => {
  isRunning.current = false; // Recovery nach vorherigem Hang
  const timer = setTimeout(() => performRun({ source: "startup" }), 3000);
  return () => clearTimeout(timer);
}, [performRun]);
```
Kostet nichts und schützt User mit einem alten APK-Zustand beim Neustart.

## NICHT geändert
- VFS-Registration aus Hotfix #1 — ist korrekt und bleibt drin
- `PdfArchiveSettings.jsx` — Toast-Dismiss-Logik ist bulletproof
- `googleDrivePdfArchive.js`, `pdfArchiveTargets.js` — andere Code-Pfade

## Test plan

- [x] `npm run lint` → 0 errors
- [x] `npm run build` → ✓
- [x] `npm test` → 169/169 passing
- [ ] Neuer APK-Build + `npx cap sync android`
- [ ] App öffnen → Settings → PDF-Archiv → „Jetzt ausführen" → Toast wechselt in <1 s
- [ ] `Documents/eStundnzettl/Archiv/Stundenzettel_YYYY-MM_<Name>.pdf` existiert, ist durchsuchbar
- [ ] Zweiter Tap ohne Datenänderung → Hash-Skip, keine neue Datei

## Follow-up (NICHT in diesem PR)
- pdfmake zu `vite.config.js` `manualChunks` → aktuell im Vendor-Chunk (Kosmetik)
- Unit-Test `pdfArchive.test.js` der `generateMonthlyPdfBlob` end-to-end exerziert, um API-Bruch bei künftigen Library-Updates früh zu fangen

https://claude.ai/code/session_01SkaYZAd5id2sQRL6kThg35