### PR TITLE
fix(archive): Local EACCES Fallback-Kette + GDrive Multipart-Body

### DIFF
--- a/src/hooks/useAutoPdfArchive.js
+++ b/src/hooks/useAutoPdfArchive.js
@@ -92,7 +92,7 @@ async function runForMonth({ entries, userData, workCodes, year, month, targets 
     results.push(await uploadNextcloudArchive(filename, base64));
   }
   if (targets.gdrive) {
-    results.push(await uploadGDriveArchive(filename, blob));
+    results.push(await uploadGDriveArchive(filename, base64, blob));
   }
 
   const anyOk = results.some((r) => r.ok);

--- a/src/utils/googleDrivePdfArchive.js
+++ b/src/utils/googleDrivePdfArchive.js
@@ -362,32 +362,46 @@ async function findFileIdInFolder(fileName, folderId) {
  * Laedt ein PDF in den `eStundnzettl Archiv`-Ordner hoch. Existiert bereits
  * eine Datei mit gleichem Namen → Update (PATCH); sonst → neu erstellen (POST).
  *
- * @param {string} filename   z.B. 'Stundenzettel_2026-04_Max.pdf'
- * @param {Blob}   blob       PDF-Blob (aus pdfmake.createPdf().getBlob())
+ * Body-Konstruktion: Wir bauen den multipart/related-Body als **reinen String**
+ * mit base64-codiertem Binary-Teil — byte-identisches Muster wie im bewaehrten
+ * JSON-Backup (`googleDriveBackup.js:253-266`, `createMultipartBody`), das seit
+ * Monaten stabil laeuft. Ein Versuch mit `new Blob([str, str, blob, str])`
+ * fuehrte auf Android-WebView zu "400 Invalid multipart request with 0 mime
+ * parts" — vermutlich weil der Blob-Serializer die Content-Type-Header-Absicht
+ * nicht zuverlaessig umsetzt und/oder der leading-dash-Boundary Parser-Quirks
+ * ausloest. Der String-Ansatz umgeht beide Probleme.
+ *
+ * @param {string} filename  z.B. 'Stundenzettel_2026-04_Max.pdf'
+ * @param {string} base64    base64-kodierter PDF-Inhalt (ohne data:-Prefix)
+ * @param {Blob}   [_blob]   Ignoriert — bleibt fuer API-Kompatibilitaet
  */
-export async function uploadPdfArchiveFile(filename, blob) {
+export async function uploadPdfArchiveFile(filename, base64, _blob) {
+  if (!base64 || typeof base64 !== 'string') {
+    throw new Error('uploadPdfArchiveFile: base64 fehlt oder ist kein String');
+  }
+
   const folderId = await findOrCreateArchiveFolder();
   const existingId = await findFileIdInFolder(filename, folderId);
 
-  const boundary = `-------pdf_archive_${Date.now()}`;
   const metadata = existingId
     ? { name: filename, mimeType: 'application/pdf' }
     : { name: filename, mimeType: 'application/pdf', parents: [folderId] };
 
-  // Multipart/related Body aus Text-Parts + binaerem Blob zusammensetzen.
-  // new Blob([...]) akzeptiert eine Mischung aus Strings und Blobs und
-  // behaelt die Binaerdaten byte-genau bei.
-  const bodyBlob = new Blob(
-    [
-      `--${boundary}\r\n`,
-      'Content-Type: application/json; charset=UTF-8\r\n\r\n',
-      JSON.stringify(metadata),
-      `\r\n--${boundary}\r\n`,
-      'Content-Type: application/pdf\r\n\r\n',
-      blob,
-      `\r\n--${boundary}--`,
-    ],
-  );
+  // Alphanumerischer Boundary ohne Bindestriche — strictere Parser (wie der von
+  // Google Drive) mögen keine führenden Dashes im Boundary-Wert.
+  const boundary = 'estd_pdf_archive_boundary';
+  const delimiter = `\r\n--${boundary}\r\n`;
+  const closeDelimiter = `\r\n--${boundary}--`;
+
+  const body =
+    delimiter +
+    'Content-Type: application/json; charset=UTF-8\r\n\r\n' +
+    JSON.stringify(metadata) +
+    delimiter +
+    'Content-Type: application/pdf\r\n' +
+    'Content-Transfer-Encoding: base64\r\n\r\n' +
+    base64 +
+    closeDelimiter;
 
   const url = existingId
     ? `https://www.googleapis.com/upload/drive/v3/files/${existingId}?uploadType=multipart`
@@ -398,7 +412,7 @@ export async function uploadPdfArchiveFile(filename, blob) {
     headers: {
       'Content-Type': `multipart/related; boundary=${boundary}`,
     },
-    body: bodyBlob,
+    body,
   });
 
   if (!response.ok) {

--- a/src/utils/pdfArchiveTargets.js
+++ b/src/utils/pdfArchiveTargets.js
@@ -18,7 +18,16 @@ import { logger } from "./logger";
 const log = logger.scope("PdfArchive");
 
 /**
- * Schreibt das PDF in den lokalen Ordner Documents/eStundnzettl/Archiv/.
+ * Schreibt das PDF in einen lokalen, ohne App zugaenglichen Ordner.
+ *
+ * Android Scoped Storage (ab 10/11) ist bei manchen Geraetekonfigurationen
+ * (Secondary User Profiles, Work Profiles, Samsung Secure Folder) besonders
+ * restriktiv — ein direkter Schreibzugriff auf `Documents/Unterordner/` kann
+ * mit `EACCES` scheitern. Daher probieren wir eine **dreistufige Fallback-
+ * Kette** und geben im Return-Objekt via `note` zurueck, welcher Pfad
+ * tatsaechlich verwendet wurde, damit die UI dem Nutzer die richtige Stelle
+ * anzeigen kann.
+ *
  * Web-Fallback: Download via Blob-URL.
  */
 export async function writeLocalArchive(filename, base64, blob) {
@@ -36,6 +45,8 @@ export async function writeLocalArchive(filename, base64, blob) {
     return { ok: true, target: "local-web" };
   }
 
+  // Stufe 1: Documents/eStundnzettl/Archiv/ (idealer Pfad, im Dateimanager
+  // unter "Dokumente" sichtbar)
   try {
     await Filesystem.writeFile({
       path: `eStundnzettl/Archiv/${filename}`,
@@ -43,10 +54,52 @@ export async function writeLocalArchive(filename, base64, blob) {
       directory: Directory.Documents,
       recursive: true,
     });
-    return { ok: true, target: "local" };
-  } catch (err) {
-    log.warn("Lokales PDF-Archiv fehlgeschlagen:", err);
-    return { ok: false, error: String(err?.message || err), target: "local" };
+    return { ok: true, target: "local", note: "Dokumente/eStundnzettl/Archiv/" };
+  } catch (err1) {
+    log.warn("Stufe 1 (Documents/eStundnzettl/Archiv) fehlgeschlagen:", err1);
+  }
+
+  // Stufe 2: Documents/ flach (MediaStore handhabt direkte Documents-Ablage
+  // zuverlaessiger als verschachtelte Pfade auf manchen Geraetekonfigurationen)
+  try {
+    await Filesystem.writeFile({
+      path: filename,
+      data: base64,
+      directory: Directory.Documents,
+    });
+    return {
+      ok: true,
+      target: "local",
+      note: "Dokumente/ (flach, ohne Unterordner)",
+    };
+  } catch (err2) {
+    log.warn("Stufe 2 (Documents/ flach) fehlgeschlagen:", err2);
+  }
+
+  // Stufe 3: App-externer privater Storage
+  // (/storage/emulated/<user>/Android/data/com.estundnzettl.app/files/Archiv/)
+  // — schreibt immer ohne Permissions. Auf Android 11+ im Standard-"Files"-App
+  // versteckt, aber mit Drittanbieter-File-Managern (Solid Explorer, MiXplorer,
+  // Cx, Total Commander) sowie per USB/adb sichtbar.
+  try {
+    await Filesystem.writeFile({
+      path: `Archiv/${filename}`,
+      data: base64,
+      directory: Directory.External,
+      recursive: true,
+    });
+    return {
+      ok: true,
+      target: "local",
+      note: "Android/data/com.estundnzettl.app/files/Archiv/ (app-privat)",
+    };
+  } catch (err3) {
+    log.warn("Stufe 3 (External/Archiv) fehlgeschlagen:", err3);
+    return {
+      ok: false,
+      error: `Alle drei Lokal-Pfade scheiterten. Letzter Fehler: ${String(err3?.message || err3)}`,
+      target: "local",
+    };
   }
 }
 
@@ -87,12 +140,12 @@ export async function uploadNextcloudArchive(filename, base64) {
  * (`googleDriveBackup.js`) nicht beruehrt — eigener Scope (drive.file),
  * eigener Session-Token-Cache, eigener localStorage-Auth-State.
  */
-export async function uploadGDriveArchive(filename, blob) {
-  if (!blob) {
-    return { ok: false, error: "Kein Blob fuer GDrive-Upload", target: "gdrive" };
+export async function uploadGDriveArchive(filename, base64, blob) {
+  if (!base64) {
+    return { ok: false, error: "Kein base64-Inhalt fuer GDrive-Upload", target: "gdrive" };
   }
   try {
-    await uploadPdfArchiveFile(filename, blob);
+    await uploadPdfArchiveFile(filename, base64, blob);
     return { ok: true, target: "gdrive" };
   } catch (err) {
     log.warn("GDrive PDF-Archiv fehlgeschlagen:", err);


### PR DESCRIPTION
## Problem

Nach Hotfix #2 (PR #8, Promise-API) wird die PDF **erfolgreich generiert**, aber zwei der drei Upload-Ziele scheitern mit unterschiedlichen Fehlern. Nextcloud läuft sauber durch.

```
local:  'writeFile' failed with: /storage/emulated/10/Documents/eStundnzettl/
        Archiv/Stundenzettel_2026-04_Markus_Kainer.pdf:
        open failed: EACCES (Permission denied)

gdrive: PDF upload failed: 400 Invalid multipart request with 0 mime parts
```

## Fehler 1: Local EACCES

**Ursache**: `/storage/emulated/10/` ist User-Profil 10 des Android-Geräts (Secondary User, Work Profile oder Samsung Secure Folder — Hauptuser ist 0). Auf solchen Profilen ist Android Scoped Storage besonders restriktiv, und Capacitors `Directory.Documents` versucht den Schreibzugriff auf einen verschachtelten Unterordner via nativem `open()`, was ohne MediaStore-Mediation blockiert wird.

**Fix** (`src/utils/pdfArchiveTargets.js`, `writeLocalArchive`): Dreistufige Fallback-Kette statt eines einzelnen Write-Versuchs:

| Stufe | Pfad | Zweck |
|---|---|---|
| 1 | `Documents/eStundnzettl/Archiv/<file>` | Ideal — voll sichtbar im Dateimanager |
| 2 | `Documents/<file>` flach | MediaStore-freundlicher (keine verschachtelten Pfade) |
| 3 | `Directory.External/Archiv/<file>` | App-gescopter Storage, schreibt **immer** ohne Permissions |

Das Return-Objekt trägt jetzt ein `note`-Feld, das zeigt, wo die Datei tatsächlich gelandet ist — so siehst du in der UI sofort, welche Stufe gegriffen hat.

Stufe 3 landet unter `Android/data/com.estundnzettl.app/files/Archiv/` — auf Android 11+ im Standard-"Files by Google"-App versteckt, aber mit Drittanbieter-File-Managern (Solid Explorer, MiXplorer, Cx, Total Commander) sowie per USB/adb sichtbar. Das erfüllt das "lesbar ohne App"-Ziel immer noch.

## Fehler 2: GDrive 400 "Invalid multipart request with 0 mime parts"

**Ursache** (`src/utils/googleDrivePdfArchive.js:368-402`): Mein Multipart-Body wurde als `new Blob([str, str, blob, str])` — ein Mix aus Text- und Binär-Teilen — konstruiert. Drei Probleme:

1. **Leading hyphens im Boundary**: `-------pdf_archive_${Date.now()}` hat 7 führende Bindestriche → Body-Delimiter hat 9 Bindestriche → Googles Parser mag das nicht
2. **Fehlender CRLF-Preamble**: Der erste Delimiter startete mit `--{boundary}\r\n` direkt, nicht mit `\r\n--{boundary}\r\n`. RFC 2046 und Googles Parser erwarten den CRLF-Preamble
3. **Mixed-Blob-Body auf Android WebView**: `fetch(url, { body: mixedBlob, headers: { 'Content-Type': 'multipart/related; boundary=X' } })` serialisiert den gemischten Blob auf manchen WebView-Versionen nicht konsistent — der vom Header deklarierte Boundary stimmt nicht mit dem gesendeten Body überein

**Fix**: Das **bewährte Muster aus `googleDriveBackup.js:253-266`** (JSON-Backup, läuft seit Monaten stabil) 1:1 übernehmen, mit Base64-Codierung für den binären Teil:

```js
const boundary = 'estd_pdf_archive_boundary';  // alphanumerisch, ohne Dash
const delimiter = `\r\n--${boundary}\r\n`;
const closeDelimiter = `\r\n--${boundary}--`;

const body =
  delimiter +
  'Content-Type: application/json; charset=UTF-8\r\n\r\n' +
  JSON.stringify(metadata) +
  delimiter +
  'Content-Type: application/pdf\r\n' +
  'Content-Transfer-Encoding: base64\r\n\r\n' +
  base64 +
  closeDelimiter;

// body ist jetzt ein reiner String — keine Blob-Gymnastik, keine WebView-Quirks
```

**Signatur-Änderung**: `uploadPdfArchiveFile(filename, blob)` → `uploadPdfArchiveFile(filename, base64, _blob)`. Der `base64`-Wert wird vom Aufrufer (`runForMonth` in `useAutoPdfArchive.js`) durchgereicht — er berechnet ihn ohnehin schon via `blobToBase64(blob)` für die anderen Upload-Ziele.

## Geänderte Dateien

- `src/utils/googleDrivePdfArchive.js` — `uploadPdfArchiveFile` auf String-Body + base64 umgestellt
- `src/utils/pdfArchiveTargets.js` — `writeLocalArchive` dreistufige Fallback-Kette; `uploadGDriveArchive` Signatur auf `(filename, base64, blob)`
- `src/hooks/useAutoPdfArchive.js` — Call-Site von `uploadGDriveArchive` übergibt jetzt `base64`

## NICHT geändert
- `src/utils/googleDriveBackup.js` — Referenz-Implementierung, bleibt unberührt
- `src/utils/pdfArchive.js` — PDF-Generierung läuft bereits
- `src/components/Settings/PdfArchiveSettings.jsx` — UI-Logik unverändert
- Nextcloud-Pfad — funktioniert bereits

## Test plan

- [x] `npm run lint` → 0 errors (25 pre-existing warnings unverändert)
- [x] `npm run build` → ✓
- [x] `npm test` → 169/169 passing
- [ ] Neuer APK-Build + `npx cap sync android`
- [ ] Settings → PDF-Archiv → „Jetzt ausführen" → Toast wechselt in <2 s auf „PDF-Archiv aktualisiert" **ohne Fehler-Badge**
- [ ] Dateimanager öffnen → PDF liegt entweder in `Documents/eStundnzettl/Archiv/` oder `Documents/` flach oder `Android/data/com.estundnzettl.app/files/Archiv/` (je nachdem welche Stufe greift — das Result-Objekt trägt einen `note`-String)
- [ ] drive.google.com → Ordner `eStundnzettl Archiv` enthält die PDF
- [ ] Zweiter Tap ohne Datenänderung → „Nichts zu tun — Daten sind aktuell" (Hash-Skip)
- [ ] Datei in Drive manuell aktualisieren, dritter Tap → überschreibt (PATCH)

https://claude.ai/code/session_01SkaYZAd5id2sQRL6kThg35