### PR TITLE
fix(gdrive): Scope-Pollution im JSON-Backup nach PDF-Archiv-Verbindung

### DIFF
--- a/src/utils/googleDriveBackup.js
+++ b/src/utils/googleDriveBackup.js
@@ -86,7 +86,13 @@ const getNativeStatus = async () => {
   }
 
   try {
-    const result = await GoogleDriveBackupPlugin.getStatus();
+    // WICHTIG: Scope MUSS explizit uebergeben werden, sonst nimmt der native
+    // Plugin seinen persistierten lastGrantedScope-Default. Wenn kurz vorher
+    // das PDF-Archiv-Modul (googleDrivePdfArchive.js) mit scope: drive.file
+    // aufgerufen wurde, steht der Default auf drive.file — ohne explizites
+    // Scope wuerde dieser Call dann ein drive.file-Token zurueckliefern und
+    // das JSON-Backup wuerde "NEED_REMOTE_CONSENT" im Auth-Log triggern.
+    const result = await GoogleDriveBackupPlugin.getStatus({ scope: AUTH_SCOPE });
     const accountEmail = result?.accountEmail || stored?.accountEmail || null;
     return {
       available: true,
@@ -162,6 +168,13 @@ const disconnectGoogleDrive = async () => {
 
   if (await nativeAvailable()) {
     try {
+      // Scope vor disconnect() explizit auf drive.appdata setzen, damit der
+      // Plugin-interne Revoke-Flow den RICHTIGEN Scope revoked — und nicht
+      // einen durch das PDF-Archiv-Modul polluted drive.file. getStatus()
+      // mit explizitem Scope setzt den nativen lastGrantedScope zurueck,
+      // bevor disconnect() ihn fuer den Revoke-Call nutzt. Analog zum Pattern
+      // in disconnectGoogleDrivePdf (googleDrivePdfArchive.js).
+      await GoogleDriveBackupPlugin.getStatus({ scope: AUTH_SCOPE });
       await GoogleDriveBackupPlugin.disconnect();
     } catch {
       // local state already cleared


### PR DESCRIPTION
## Problem

Nach dem PDF-Archiv-Feature (Iteration 2, PR #6) zeigt die **bestehende JSON-Backup-Card** eine gelbe Warnung _"Letzte Backups fehlgeschlagen, bitte Drive-Verbindung prüfen"_ — obwohl der Backup-Upload selbst weiterhin durchläuft (OK-Toast wird angezeigt). Android-Logs bestätigen das Muster:

```
W/Auth: [RequestTokenManager] getToken() -> NEED_REMOTE_CONSENT.
        App: com.estundnzettl.app, Service: oauth2:email https://www.googleapis.com/auth/drive.appdata
```

Und zwar **bei jedem App-Resume**, nicht nur einmalig.

## Root Cause

Das ist **genau die Regression, vor der ich in Iteration 2 gewarnt hatte** — mit einer Stelle, die ich übersehen habe.

Der native Plugin `GoogleDriveBackupPlugin.java` hält `lastGrantedScope` als **einziges Feld in SharedPreferences**. Meine Strategie in Iteration 2 war: die JS-Seite übergibt bei jedem Call den scope explizit, damit der persistente Default irrelevant wird. Das habe ich in `googleDrivePdfArchive.js` auch konsequent gemacht (alle 5 Plugin-Calls haben `scope: AUTH_SCOPE_PDF`).

**Übersehen habe ich**: `src/utils/googleDriveBackup.js:89` ruft
```js
const result = await GoogleDriveBackupPlugin.getStatus();  // ← KEIN scope-Param
```

Datenfluss der Pollution:

1. Nutzer öffnet Settings → `PdfArchiveSettings.jsx` mount-`useEffect` ruft `getGoogleDrivePdfStatus()`
2. Das ruft `GoogleDriveBackupPlugin.getStatus({ scope: drive.file })`
3. Native Plugin persistiert `lastGrantedScope = drive.file` in SharedPrefs (`GoogleDriveBackupPlugin.java:397`)
4. Kurz danach ruft `BackupSettings.jsx` mount-`useEffect` → `getNativeStatus()` → `GoogleDriveBackupPlugin.getStatus()` **ohne Scope**
5. Plugin nimmt persistierten Default → `drive.file` statt `drive.appdata`
6. Silent Authorize mit falschem Scope → GMS meldet `NEED_REMOTE_CONSENT` für den von JSON-Backup eigentlich benötigten `drive.appdata`
7. `getNativeStatus()` liefert `hasToken: false` → UI zeigt gelbe Warnung

Der tatsächliche Upload-Pfad funktioniert trotzdem, weil `getValidGoogleToken` (`googleDriveBackup.js:172`) den Scope explizit an `refreshToken({scope: AUTH_SCOPE})` weitergibt (Zeile 184).

## Fix

**Zwei chirurgische Änderungen in `src/utils/googleDriveBackup.js`**, alles andere bleibt unberührt:

### Änderung 1 (Zeile 89) — Status-Read mit explizitem Scope
```js
// Vorher:
const result = await GoogleDriveBackupPlugin.getStatus();

// Nachher:
const result = await GoogleDriveBackupPlugin.getStatus({ scope: AUTH_SCOPE });
```
Das verhindert, dass der JSON-Backup-Status-Read den polluteten Plugin-Default liest. Gleichzeitig setzt dieser Call den nativen `lastGrantedScope` auf `drive.appdata` zurück — **Self-Healing** für Bestandsnutzer beim nächsten App-Start.

### Änderung 2 (Zeile 160-170) — Scope-Prime vor `disconnect()`
```js
const disconnectGoogleDrive = async () => {
  clearStoredAuth();
  if (await nativeAvailable()) {
    try {
      await GoogleDriveBackupPlugin.getStatus({ scope: AUTH_SCOPE });  // ← neu
      await GoogleDriveBackupPlugin.disconnect();
    } catch { /* local state already cleared */ }
  }
};
```
`disconnect()` hat keinen Scope-Parameter und nutzt intern `lastGrantedScope` für den Revoke-Call. Der `getStatus`-Call davor setzt den richtigen Scope, bevor `disconnect` ihn liest. Analog zum Pattern, das ich in Iteration 2 bereits in `disconnectGoogleDrivePdf` eingebaut habe.

## Warum nur diese beiden Stellen

Ich habe mit `Grep` nach allen `GoogleDriveBackupPlugin\.`-Aufrufen in der Codebase gesucht:

| Datei:Zeile | Call | Scope explizit? |
|---|---|---|
| `googleDriveBackup.js:89` | `getStatus()` | ❌ → **Fix 1** |
| `googleDriveBackup.js:128` | `connect({ scope: AUTH_SCOPE })` | ✅ |
| `googleDriveBackup.js:165` | `disconnect()` | ❌ (kein scope-Param) → **Fix 2** |
| `googleDriveBackup.js:184` | `refreshToken({ scope: AUTH_SCOPE })` | ✅ |
| `googleDrivePdfArchive.js:119` | `connect({ scope: AUTH_SCOPE_PDF })` | ✅ |
| `googleDrivePdfArchive.js:160` | `getStatus({ scope: AUTH_SCOPE_PDF })` | ✅ |
| `googleDrivePdfArchive.js:161` | `disconnect()` | ✅ (wird durch `getStatus` davor geprimt) |
| `googleDrivePdfArchive.js:181` | `refreshToken({ scope: AUTH_SCOPE_PDF })` | ✅ |
| `googleDrivePdfArchive.js:226` | `getStatus({ scope: AUTH_SCOPE_PDF })` | ✅ |

Nur die zwei oben genannten Stellen brauchen den Fix.

## NICHT geändert
- **`GoogleDriveBackupPlugin.java`** — kein nativer Eingriff, kein neuer APK-Build nötig für die Plugin-Seite
- **`googleDrivePdfArchive.js`** — bereits korrekt
- **`useAutoBackup.js`** — nutzt `getValidGoogleToken` mit explizitem Scope

## Self-Healing für Bestandsnutzer

Das schöne am Fix: Nutzer, die **jetzt** einen polluteten Plugin-State haben (`SharedPrefs.KEY_SCOPE = drive.file`), werden nach dem Update beim nächsten App-Start automatisch geheilt. Der erste `getNativeStatus()`-Call aus `BackupSettings.jsx` setzt den Plugin-State zurück auf `drive.appdata`. Die gelbe Warnung verschwindet beim nächsten Foreground-Wechsel, ohne dass der Nutzer etwas tun muss.

## Follow-up (nicht in diesem PR)

Eine robustere Langzeit-Lösung wäre, `GoogleDriveBackupPlugin.java` so umzubauen, dass `lastGrantedScope` **nicht** in SharedPreferences persistiert wird — nur als Session-Variable oder (sauberer) als zwei separate Slots für `drive.appdata` und `drive.file`. Das würde verhindern, dass überhaupt je wieder ein scope-loser JS-Call die gesamte Klasse polluten kann. Für jetzt reicht die JS-defensive Variante; den nativen Refactor kann ich in einer späteren PR nachziehen, falls gewünscht.

## Test plan

- [x] `npm run lint` → 0 errors (25 pre-existing warnings unverändert)
- [x] `npm run build` → ✓
- [x] `npm test` → 169/169 passing
- [ ] Nach `npx cap sync android` + neuem APK:
  - [ ] App öffnen, Settings ansehen → gelbe "Drive-Verbindung prüfen"-Warnung sollte **weg** sein
  - [ ] Backup-Card "Jetzt sichern" → OK-Toast + keine neue Warnung
  - [ ] Logcat mit `adb logcat | grep NEED_REMOTE_CONSENT` → keine neuen Meldungen mehr für `drive.appdata`
  - [ ] PDF-Archiv "Jetzt ausführen" → weiterhin grün (Local + GDrive + Nextcloud)
  - [ ] drive.google.com → Ordner "eStundnzettl Archiv" ist weiter da, neue PDF-Versionen werden gespeichert

https://claude.ai/code/session_01SkaYZAd5id2sQRL6kThg35