### PR TITLE
chore(release): v3.3.0 — Automatisches PDF-Archiv

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "com.estundnzettl.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 199
-        versionName "3.2.1"
+        versionCode 200
+        versionName "3.3.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eStundnzettl",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eStundnzettl",
-      "version": "3.2.1",
+      "version": "3.3.0",
       "hasInstallScript": true,
       "dependencies": {
         "@capacitor-community/date-picker": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eStundnzettl",
   "private": true,
-  "version": "3.2.1",
+  "version": "3.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/data/changelog-data.js
+++ b/src/data/changelog-data.js
@@ -1,6 +1,30 @@
 export const CHANGELOG_DATA = [
 
   {
+    version: "3.3.0",
+    date: "05.04.2026",
+    title: "Dein Monats-PDF landet von selbst im Archiv 📁",
+    sections: [
+      {
+        iconName: "FileText",
+        title: "Automatisches PDF-Archiv",
+        items: [
+          "Die App legt dir ab jetzt jeden Monat automatisch ein sauberes PDF deines Stundenzettels an — einmal pro Tag, ganz ohne dein Zutun. So hast du auch Jahre später einen ordentlichen, durchsuchbaren Monatsbericht parat, selbst wenn die App dann gar nicht mehr installiert sein sollte.",
+          "In den Einstellungen kannst du aussuchen, wohin das Archiv gehen soll: lokal auf dein Gerät in den Dokumente-Ordner, in deine Nextcloud oder zu Google Drive in einen eigenen Ordner \"eStundnzettl Archiv\". Jedes Ziel lässt sich einzeln ein- und ausschalten, und mit \"Jetzt ausführen\" kannst du jederzeit selbst einen Lauf starten.",
+          "Beim Monatswechsel wird der alte Monat als finaler Bericht stehengelassen und ein neuer begonnen. Und solange sich an deinen Einträgen nichts geändert hat, passiert auch nichts — kein unnötiger Upload, kein zusätzlicher Datenverbrauch."
+        ]
+      },
+      {
+        iconName: "ShieldCheck",
+        title: "Drive-Verbindung gschmeidiger",
+        items: [
+          "Die Google-Drive-Verbindung vom bestehenden JSON-Backup und vom neuen PDF-Archiv laufen jetzt sauber nebeneinander. Die gelbe Warnung \"Drive-Verbindung prüfen\", die bei manchen nach dem Verbinden des PDF-Archivs kurz auftauchen konnte, ist damit auch weg."
+        ]
+      }
+    ]
+  },
+
+  {
     version: "3.2.1",
     date: "05.04.2026",
     title: "Flexiblere Sonderzeiten ⏱️",


### PR DESCRIPTION
## Release v3.3.0 — Automatisches PDF-Archiv

Bündelt das neue automatische Monats-PDF-Archiv-Feature mit allen zugehörigen Hotfixes in einem sauberen Release für die Play Console.

### Version
- `package.json`: 3.2.1 → **3.3.0**
- `android/app/build.gradle`: versionName **3.3.0**, versionCode **200**

### Enthaltene PRs seit 3.2.1
- #5 — Iteration 1: pdfmake-Generator, Scheduler, Local + Nextcloud Targets, Settings-UI
- #6 — Iteration 2: Google-Drive-Target mit eigenem `drive.file`-Scope
- #7 — Hotfix: pdfmake VFS-Registration auf Android
- #8 — Hotfix: pdfmake 0.3.x Promise-API
- #9 — Hotfix: Local EACCES Fallback-Kette + GDrive Multipart-Body
- #10 — Hotfix: Scope-Pollution im bestehenden JSON-Backup

Alle sechs PRs sind bereits auf `main` und vom Nutzer auf dem Gerät verifiziert: Local legt die PDF ab, GDrive landet im sichtbaren Archiv-Ordner, JSON-Backup läuft ohne Warnung.

### Changelog-Eintrag (neu in `src/data/changelog-data.js`)

> **Dein Monats-PDF landet von selbst im Archiv 📁**
>
> **Automatisches PDF-Archiv**
> - Die App legt dir ab jetzt jeden Monat automatisch ein sauberes PDF deines Stundenzettels an — einmal pro Tag, ganz ohne dein Zutun. So hast du auch Jahre später einen ordentlichen, durchsuchbaren Monatsbericht parat, selbst wenn die App dann gar nicht mehr installiert sein sollte.
> - In den Einstellungen kannst du aussuchen, wohin das Archiv gehen soll: lokal auf dein Gerät in den Dokumente-Ordner, in deine Nextcloud oder zu Google Drive in einen eigenen Ordner "eStundnzettl Archiv". Jedes Ziel lässt sich einzeln ein- und ausschalten, und mit "Jetzt ausführen" kannst du jederzeit selbst einen Lauf starten.
> - Beim Monatswechsel wird der alte Monat als finaler Bericht stehengelassen und ein neuer begonnen. Und solange sich an deinen Einträgen nichts geändert hat, passiert auch nichts — kein unnötiger Upload, kein zusätzlicher Datenverbrauch.
>
> **Drive-Verbindung gschmeidiger**
> - Die Google-Drive-Verbindung vom bestehenden JSON-Backup und vom neuen PDF-Archiv laufen jetzt sauber nebeneinander. Die gelbe Warnung "Drive-Verbindung prüfen", die bei manchen nach dem Verbinden des PDF-Archivs kurz auftauchen konnte, ist damit auch weg.

### Release-Gate
- [x] Lint: 0 Errors
- [x] Build: ✓
- [x] Tests: 169/169 passing
- [x] `package.json`, `package-lock.json`, `android/app/build.gradle`, `src/data/changelog-data.js` konsistent

## Test plan
- [ ] APK aus 3.3.0 (versionCode 200) bauen
- [ ] Installieren und App-Footer auf v3.3.0 prüfen
- [ ] Changelog-Screen zeigt neuen Eintrag ganz oben
- [ ] In die Play Console hochladen (internal track)

https://claude.ai/code/session_01SkaYZAd5id2sQRL6kThg35