### PR TITLE
fix: Nextcloud Login URL Key mismatch

### DIFF
--- a/src/plugins/NextcloudLoginFlowPlugin.ts
+++ b/src/plugins/NextcloudLoginFlowPlugin.ts
@@ -24,7 +24,7 @@ export interface NextcloudHttpRequestResult {
 }
 
 export interface NextcloudLoginFlowPlugin {
-  startLoginFlow(options: { url: string }): Promise<NextcloudLoginFlowResult & { ok: boolean }>;
+  startLoginFlow(options: { serverUrl: string }): Promise<NextcloudLoginFlowResult & { ok: boolean }>;
   pollLoginFlow(options: { pollEndpoint: string; token: string }): Promise<NextcloudLoginFlowResult & { ok: boolean; status?: string }>;
   httpRequest(options: NextcloudHttpRequestOptions): Promise<NextcloudHttpRequestResult>;
 }

--- a/src/utils/nextcloudClient.ts
+++ b/src/utils/nextcloudClient.ts
@@ -100,7 +100,7 @@ export async function initiateLoginFlow(serverUrl: string): Promise<NcResult> {
 
   if (Capacitor.getPlatform() === 'android') {
     try {
-      return await NextcloudLoginFlow.startLoginFlow({ url: normalized.value as string }) as unknown as NcResult;
+      return await NextcloudLoginFlow.startLoginFlow({ serverUrl: normalized.value as string } as any) as unknown as NcResult;
     } catch (error) {
       return buildError('PLUGIN_ERROR', getErrorMessage(error, 'Native Android-Integration fehlgeschlagen'), undefined, true);
     }


### PR DESCRIPTION
Fixes the 'Server Url Fehlt' error on Android by using the correct key expected by the native plugin.