### PR TITLE
refactor(types): tighten BackupAnalysisResult to a real discriminated union

### DIFF
--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -30,7 +30,7 @@ import {
   getBlankCalculationConfig,
 } from "../utils/calculationConfig";
 
-import type { Entry, UserData, WorkCode, Theme, WorkModel, GoogleSignInResult, BackupAnalysisResult, CalculationConfig } from "../types";
+import type { Entry, UserData, WorkCode, Theme, WorkModel, GoogleSignInResult, BackupAnalysisData, CalculationConfig } from "../types";
 
 const log = logger.scope("Onboarding");
 
@@ -101,7 +101,7 @@ const OnboardingWizard: React.FC<Props> = ({ onComplete, setUserData, importEntr
     customCalc: false,
   });
   
-  const [restoreData, setRestoreData] = useState<Record<string, unknown> | null>(null);
+  const [restoreData, setRestoreData] = useState<BackupAnalysisData | null>(null);
   const [showConflictModal, setShowConflictModal] = useState(false);
   
   const [showNcRestore, setShowNcRestore] = useState(false);
@@ -505,9 +505,9 @@ const OnboardingWizard: React.FC<Props> = ({ onComplete, setUserData, importEntr
       const content = await downloadFileContent(token as string, file.id as string);
       if (!content) throw new Error(t("onboarding.toast.backupEmpty"));
 
-      const { isValid, data } = await analyzeBackupData(content);
-      if (isValid) {
-        setRestoreData(data);
+      const result = await analyzeBackupData(content);
+      if (result.isValid) {
+        setRestoreData(result.data);
         toast.success(t("onboarding.toast.backupLoaded"));
         setStep(7);
       } else {
@@ -526,9 +526,9 @@ const OnboardingWizard: React.FC<Props> = ({ onComplete, setUserData, importEntr
       setLoading(true);
       const backupContent = await readBackupFromFolder();
       if (backupContent) {
-          const { isValid, data } = await analyzeBackupData(backupContent);
-          if (isValid) {
-              setRestoreData(data);
+          const result = await analyzeBackupData(backupContent);
+          if (result.isValid) {
+              setRestoreData(result.data);
               toast.success(t("onboarding.toast.backupLoaded"));
               setStep(7);
           } else {
@@ -550,12 +550,12 @@ const OnboardingWizard: React.FC<Props> = ({ onComplete, setUserData, importEntr
     try {
       setLoading(true);
       const content = await readJsonFile(file);
-      const { isValid, data } = await analyzeBackupData(content);
-      if (isValid) {
-        if ((data as BackupAnalysisResult).integrity === "mismatch") {
+      const result = await analyzeBackupData(content);
+      if (result.isValid) {
+        if (result.data.integrity === "mismatch") {
           toast(t("onboarding.toast.integrityMismatch"), { duration: 6000 });
         }
-        setRestoreData(data);
+        setRestoreData(result.data);
         toast.success(t("onboarding.toast.backupLoaded"));
         setStep(7);
       } else {
@@ -618,9 +618,9 @@ const OnboardingWizard: React.FC<Props> = ({ onComplete, setUserData, importEntr
                 setLoading(false);
                 return;
               }
-              const { isValid, data } = await analyzeBackupData(content);
-              if (isValid) {
-                setRestoreData(data);
+              const analysis = await analyzeBackupData(content);
+              if (analysis.isValid) {
+                setRestoreData(analysis.data);
                 toast.success(t("onboarding.toast.ncRestoreLoaded"));
                 setShowNcRestore(false);
                 setStep(7);

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -14,7 +14,7 @@ import { analyzeBackupData, applyBackup, readJsonFile } from "../utils/storageBa
 import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 
-import type { Entry, UserData, Theme, WorkCode, PdfArchiveRunOptions, CalculationConfig } from "../types";
+import type { Entry, UserData, Theme, WorkCode, PdfArchiveRunOptions, CalculationConfig, BackupAnalysisData } from "../types";
 import type { Locale, LocaleId } from "../locales/types";
 
 const ChangelogModal = React.lazy(() => import("./ChangelogModal"));
@@ -121,7 +121,7 @@ const Settings: React.FC<Props> = ({
   const [showHelp, setShowHelp] = useState(false);
   const [showWorkCodeManager, setShowWorkCodeManager] = useState(false);
 
-  const [pendingImport, setPendingImport] = useState<Record<string, unknown> | null>(null);
+  const [pendingImport, setPendingImport] = useState<BackupAnalysisData | null>(null);
 
   const [showDurationPicker, setShowDurationPicker] = useState(false);
   const [pickerTargetIndex, setPickerTargetIndex] = useState<number | null>(null);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -296,21 +296,35 @@ export interface GoogleSignInResult {
 
 // ─── Backup Analysis ────────────────────────────────────────
 
-export interface BackupAnalysisResult {
-  integrity: "ok" | "mismatch" | "missing";
+/**
+ * Concrete shape produced by `analyzeBackupData` for a valid backup.
+ * `applyBackup` consumes exactly this shape.
+ */
+export interface BackupAnalysisData {
+  valid: true;
+  entryCount: number;
+  hasSettings: boolean;
+  hasWorkCodes: boolean;
+  hasAttachments: boolean;
+  hasCalculationConfig: boolean;
   entries: Entry[];
+  settings: Record<string, unknown> | null;
   workCodes: WorkCode[];
   attachments: Attachment[];
   attachmentLabels: string[];
-  settings: Record<string, unknown> | null;
+  calculationConfig: Record<string, unknown> | null;
   timestamp: string | null;
-  newEntries: number;
-  updatedEntries: number;
-  unchangedEntries: number;
-  newCodes: number;
-  newAttachments: number;
-  conflicts: Entry[];
+  integrity: string; // "verified" | "unverified" | "mismatch" | "ok" | "missing"
 }
+
+/**
+ * Discriminated return type of `analyzeBackupData`.
+ * Use `if (result.isValid)` to narrow to the data-bearing branch.
+ * The valid branch carries the data both flattened (legacy) and as `data`.
+ */
+export type BackupAnalysisResult =
+  | { valid: false; isValid: false }
+  | (BackupAnalysisData & { isValid: true; data: BackupAnalysisData });
 
 // ─── PDF Archive ────────────────────────────────────────────
 

--- a/src/utils/__tests__/storageBackup.test.ts
+++ b/src/utils/__tests__/storageBackup.test.ts
@@ -125,7 +125,7 @@ describe("analyzeBackupData", () => {
         { id: 1, date: "2024-01-01", type: "work" },
       ],
     });
-    expect(result.valid).toBe(true);
+    if (!result.isValid) throw new Error("expected valid result");
     expect(result.entryCount).toBe(1);
     expect(result.integrity).toBe("unverified");
   });
@@ -136,7 +136,7 @@ describe("analyzeBackupData", () => {
     };
     await attachBackupChecksum(payload);
     const result = await analyzeBackupData(payload);
-    expect(result.valid).toBe(true);
+    if (!result.isValid) throw new Error("expected valid result");
     expect(result.integrity).toBe("verified");
   });
 
@@ -147,7 +147,7 @@ describe("analyzeBackupData", () => {
     await attachBackupChecksum(payload);
     payload.entries[0].id = 999; // Manipulation
     const result = await analyzeBackupData(payload);
-    expect(result.valid).toBe(true);
+    if (!result.isValid) throw new Error("expected valid result");
     expect(result.integrity).toBe("mismatch");
   });
 
@@ -159,6 +159,7 @@ describe("analyzeBackupData", () => {
         null,
       ],
     });
+    if (!result.isValid) throw new Error("expected valid result");
     expect(result.entryCount).toBe(1);
   });
 
@@ -172,7 +173,7 @@ describe("analyzeBackupData", () => {
       ],
     });
 
-    expect(result.valid).toBe(true);
+    if (!result.isValid) throw new Error("expected valid result");
     expect((result.entries as Array<{ id: string }>)[0].id).toBe("legacy-301");
     expect((result.attachments as Array<{ entryId: string }>)[0].entryId).toBe("legacy-301");
   });

--- a/src/utils/storageBackup.ts
+++ b/src/utils/storageBackup.ts
@@ -10,7 +10,7 @@ import { getAllEntries } from "../db/repositories/entriesRepo";
 import { replaceFullSnapshot, type ImportSnapshot } from "../db/snapshot";
 import { logger } from "./logger";
 import { getErrorMessage } from "./errorUtils";
-import type { BackupAnalysisResult, CalculationConfig, UserData } from "../types";
+import type { BackupAnalysisResult, BackupAnalysisData, CalculationConfig, UserData, Entry, WorkCode, Attachment } from "../types";
 
 // =========================================================
 // BACKUP ORDNER
@@ -92,13 +92,14 @@ function redactBackupErrorMessage(error: unknown, fallback: string): string {
  *  - "mismatch":   Checksum vorhanden, aber inkorrekt (möglicher Tampering)
  *  - "unverified": Kein Checksum-Feld (Legacy-Backup)
  */
-export async function verifyBackupIntegrity(payload: Record<string, unknown> | null): Promise<"verified" | "mismatch" | "unverified"> {
-  if (!payload || typeof payload !== "object") return "unverified";
-  if (typeof payload.checksum !== "string" || payload.checksum.length === 0) {
+export async function verifyBackupIntegrity(payload: unknown): Promise<"verified" | "mismatch" | "unverified"> {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return "unverified";
+  const obj = payload as Record<string, unknown>;
+  if (typeof obj.checksum !== "string" || obj.checksum.length === 0) {
     return "unverified";
   }
-  const expected = payload.checksum;
-  const actual = await computeBackupChecksum(payload);
+  const expected = obj.checksum;
+  const actual = await computeBackupChecksum(obj);
   if (!actual) return "unverified";
   return actual === expected ? "verified" : "mismatch";
 }
@@ -332,14 +333,14 @@ const isValidEntry = (entry: unknown): boolean => {
   return true;
 };
 
-const normalizeEntries = (value: unknown): unknown[] => {
+const normalizeEntries = (value: unknown): Entry[] => {
   const v = value as Record<string, unknown> | undefined;
   let raw: unknown[] = [];
   if (Array.isArray(value)) raw = value;
   else if (Array.isArray(v?.entries)) raw = v.entries as unknown[];
   else if (v?.data && typeof v.data === "object" && Array.isArray((v.data as Record<string, unknown>)?.entries)) raw = (v.data as Record<string, unknown>).entries as unknown[];
   else if (Array.isArray(v?.items)) raw = v.items as unknown[];
-  return raw.filter(isValidEntry);
+  return raw.filter(isValidEntry) as Entry[];
 };
 
 const normalizeSettings = (value: unknown): Record<string, unknown> | null => {
@@ -348,18 +349,18 @@ const normalizeSettings = (value: unknown): Record<string, unknown> | null => {
   return (v.user || v.settings || v.profile || v.userData || v.employee || null) as Record<string, unknown> | null;
 };
 
-const normalizeWorkCodes = (value: unknown): unknown[] => {
+const normalizeWorkCodes = (value: unknown): WorkCode[] => {
   if (!value || typeof value !== "object" || Array.isArray(value)) return [];
   const v = value as Record<string, unknown>;
   const raw = v.workCodes || v.codes || v.workcodes || [];
-  return Array.isArray(raw) ? raw : [];
+  return (Array.isArray(raw) ? raw : []) as WorkCode[];
 };
 
-const normalizeAttachments = (value: unknown): unknown[] => {
+const normalizeAttachments = (value: unknown): Attachment[] => {
   if (!value || typeof value !== "object" || Array.isArray(value)) return [];
   const v = value as Record<string, unknown>;
   const raw = v.attachments || v.files || [];
-  return Array.isArray(raw) ? raw : [];
+  return (Array.isArray(raw) ? raw : []) as Attachment[];
 };
 
 const normalizeAttachmentLabels = (value: unknown): string[] => {
@@ -384,7 +385,7 @@ const normalizeCalculationConfig = (value: unknown): Record<string, unknown> | n
 
 // 1. ANALYSE - Schaut in die Daten, OHNE zu speichern.
 // Async, weil die Integritätsprüfung via SHA-256 (Web Crypto) asynchron ist.
-export const analyzeBackupData = async (data: unknown): Promise<Record<string, unknown>> => {
+export const analyzeBackupData = async (data: unknown): Promise<BackupAnalysisResult> => {
   if (!data) return { valid: false, isValid: false };
 
   const entries = normalizeEntries(data);
@@ -405,7 +406,7 @@ export const analyzeBackupData = async (data: unknown): Promise<Record<string, u
     logger.warn("[analyzeBackupData] Integritätsprüfung fehlgeschlagen:", err);
   }
 
-  const analysisResult = {
+  const analysisResult: BackupAnalysisData = {
     valid: true,
     entryCount: entries.length,
     hasSettings: !!settings,
@@ -419,13 +420,13 @@ export const analyzeBackupData = async (data: unknown): Promise<Record<string, u
     attachmentLabels,
     calculationConfig,
     timestamp: normalizeTimestamp(data),
-    integrity, // "verified" | "unverified" | "mismatch"
+    integrity,
   };
 
   return {
     isValid: true,
     data: analysisResult,
-    ...analysisResult
+    ...analysisResult,
   };
 };
 
@@ -437,7 +438,7 @@ export const analyzeBackupData = async (data: unknown): Promise<Record<string, u
 // eigenen Mini-Transaktion → bei Fehler in Schritt 3 von 6 blieben die
 // ersten beiden persistiert. Mit dem Snapshot-Approach kommt jetzt
 // entweder das ganze Backup an oder gar nichts.
-export const applyBackup = async (analyzedData: BackupAnalysisResult & Record<string, unknown>, mode: string = 'ALL'): Promise<boolean> => {
+export const applyBackup = async (analyzedData: BackupAnalysisData, mode: string = 'ALL'): Promise<boolean> => {
   if (!analyzedData || !analyzedData.valid) return false;
 
   try {
@@ -459,9 +460,9 @@ export const applyBackup = async (analyzedData: BackupAnalysisResult & Record<st
         snapshot.attachmentLabels = analyzedData.attachmentLabels;
       }
 
-      const calcConfig = (analyzedData as Record<string, unknown>).calculationConfig;
-      if (mode === 'ALL' && calcConfig && typeof calcConfig === 'object') {
-        snapshot.calculationConfig = calcConfig as CalculationConfig;
+      // CalculationConfig aus Backup übernehmen (wenn mode=ALL).
+      if (mode === 'ALL' && analyzedData.calculationConfig) {
+        snapshot.calculationConfig = analyzedData.calculationConfig as CalculationConfig;
       }
 
       await replaceFullSnapshot(snapshot);


### PR DESCRIPTION
## Summary
`analyzeBackupData` was returning `Promise<Record<string, unknown>>`, so every consumer either fell back to loose Record types or smuggled the data through `as` casts. This PR types the backup analysis flow honestly:

- New `BackupAnalysisData` interface documents the real payload shape (`valid`, `entryCount`, `hasSettings`, `entries`, `workCodes`, ...)
- `BackupAnalysisResult` becomes a discriminated union: `{ valid: false; isValid: false }` vs. `BackupAnalysisData & { isValid: true; data: BackupAnalysisData }`
- `analyzeBackupData` returns the union; consumers narrow via `if (result.isValid)`
- `applyBackup` takes `BackupAnalysisData` directly — the `BackupAnalysisResult & Record<string, unknown>` intersection workaround is gone
- `normalize*` helpers return concrete typed arrays so flow analysis carries through
- `verifyBackupIntegrity` parameter widened to `unknown` (it already validated internally), removes a forced cast
- `Settings.tsx` and `OnboardingWizard.tsx` use the narrowed types
- Tests use the `isValid` discriminator instead of accessing flat fields blindly

## Why
The old shape produced "looks-fine" code that hid real bugs behind `Record<string, unknown>` casts. After this PR, any future field that's added to `BackupAnalysisData` is automatically visible to all consumers without further plumbing.

## Dead fields removed
The old `BackupAnalysisResult` had `newEntries`, `updatedEntries`, `unchangedEntries`, `newCodes`, `newAttachments`, `conflicts` — none of which are produced by `analyzeBackupData` or read anywhere in `src/`. Looked like a never-implemented conflict-preview feature. Removed.

## Impact on TypeScript errors
- **Before:** 62 errors (across 25 files)
- **After:** 46 errors
- **Cluster fully resolved:** Settings.tsx (9 → 0), OnboardingWizard.tsx (7 → 1; the remaining error is an unrelated `FormData`/`OnboardingFormData` mismatch on line 689)

## Test plan
- [x] 758/758 unit tests pass (the 5 storageBackup tests were updated for the new narrowing pattern; semantics unchanged)
- [x] `npm run lint` — 0 errors (warnings unchanged)
- [x] `npm run build` — clean
- [ ] Manual: import a JSON backup via Settings → entries appear, `entryCount` toast correct
- [ ] Manual: onboarding restore from local file with `integrity: "mismatch"` → warning toast still fires
- [ ] Manual: confirm import conflict modal still shows entry count

## Out of scope (further follow-up PRs)
- 46 remaining TS errors across other clusters (Settings/, App.tsx, hooks, tests, googleDrive*, db/*) — addressed cluster-by-cluster in subsequent PRs
- Adding `tsc --noEmit` to CI — only meaningful once all clusters are clean, otherwise the gate stays red

🤖 Generated with [Claude Code](https://claude.com/claude-code)