### PR TITLE
chore(db): use real capSQLiteChanges type and tighten migration casts

### DIFF
--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -7,7 +7,7 @@
  * eStundnzettl ist eine reine Android-App — SQLite ist IMMER verfügbar.
  */
 
-import { CapacitorSQLite } from "@capacitor-community/sqlite";
+import { CapacitorSQLite, type capSQLiteChanges } from "@capacitor-community/sqlite";
 import { DB_NAME } from "./schema";
 import { runMigrations } from "./migrations";
 import { logger } from "../utils/logger";
@@ -58,7 +58,7 @@ async function init(): Promise<boolean> {
     _dbOpen = true;
 
     // Schema über Migrations-Framework aktualisieren (idempotent + versioniert)
-    const executeFn = (sql: string): Promise<{ changes?: { changes: number } }> =>
+    const executeFn = (sql: string): Promise<capSQLiteChanges> =>
       CapacitorSQLite.execute({ database: DB_NAME, statements: sql });
     const queryFn = async (sql: string): Promise<Record<string, unknown>[]> => {
       // ACHTUNG: @capacitor-community/sqlite verlangt `values` als Pflichtfeld,
@@ -131,7 +131,7 @@ export async function closeDb(): Promise<void> {
 /**
  * Raw execute — führt beliebiges SQL aus (DDL, multi-statement).
  */
-export async function execute(sql: string): Promise<{ changes?: { changes: number } }> {
+export async function execute(sql: string): Promise<capSQLiteChanges> {
   const db = await getDb();
   return CapacitorSQLite.execute({ database: db!, statements: sql });
 }
@@ -139,7 +139,7 @@ export async function execute(sql: string): Promise<{ changes?: { changes: numbe
 /**
  * Raw run — einzelnes Statement mit Parametern (INSERT/UPDATE/DELETE).
  */
-export async function run(sql: string, values: SqlValue[] = []): Promise<{ changes?: { changes: number; lastId?: number } }> {
+export async function run(sql: string, values: SqlValue[] = []): Promise<capSQLiteChanges> {
   const db = await getDb();
   return CapacitorSQLite.run({ database: db!, statement: sql, values });
 }
@@ -149,7 +149,7 @@ export async function run(sql: string, values: SqlValue[] = []): Promise<{ chang
  * @param {Array<{statement: string, values: Array}>} set
  * @param {boolean} [transaction=true] — in Transaktion wrappen
  */
-export async function executeSet(set: Array<{ statement: string; values: SqlValue[] }>, transaction: boolean = true): Promise<{ changes?: { changes: number } } | void> {
+export async function executeSet(set: Array<{ statement: string; values: SqlValue[] }>, transaction: boolean = true): Promise<capSQLiteChanges | void> {
   if (!set || set.length === 0) return;
   const db = await getDb();
   return CapacitorSQLite.executeSet({ database: db!, set, transaction });

--- a/src/db/migrate-from-localstorage.ts
+++ b/src/db/migrate-from-localstorage.ts
@@ -17,6 +17,7 @@ import { bulkWriteSettings } from "./repositories/settingsRepo";
 import { bulkReplaceWorkCodes } from "./repositories/workCodesRepo";
 import { bulkReplaceAttachments, bulkReplaceLabelSuggestions } from "./repositories/attachmentsRepo";
 import { logger } from "../utils/logger";
+import type { Entry, WorkCode, Attachment } from "../types";
 
 const readJsonSetting = (key: string): unknown => {
   try {
@@ -213,7 +214,7 @@ export async function migrateEntriesToSQLite(): Promise<MigrationResult> {
   }
 
   try {
-    await bulkInsertEntries(entries);
+    await bulkInsertEntries(entries as Entry[]);
     localStorage.setItem(MIGRATION_FLAGS.ENTRIES, "true");
     logger.info(`[migration] ${entries.length} Entries erfolgreich nach SQLite migriert`);
     return { migrated: entries.length, skipped: false };
@@ -318,7 +319,7 @@ export async function migrateWorkCodesToSQLite(): Promise<MigrationResult> {
   }
 
   try {
-    await bulkReplaceWorkCodes(codes);
+    await bulkReplaceWorkCodes(codes as WorkCode[]);
     localStorage.setItem(MIGRATION_FLAGS.WORK_CODES, "true");
     logger.info(`[migration] ${codes.length} WorkCodes erfolgreich nach SQLite migriert`);
     return { migrated: codes.length, skipped: false };
@@ -375,7 +376,7 @@ export async function migrateAttachmentsToSQLite(): Promise<AttachmentMigrationR
 
   try {
     if (attachments.length > 0) {
-      await bulkReplaceAttachments(attachments);
+      await bulkReplaceAttachments(attachments as Attachment[]);
     }
     if (labels.length > 0) {
       await bulkReplaceLabelSuggestions(labels);


### PR DESCRIPTION
## Summary
- `database.ts`: drops the hand-rolled `{ changes?: { changes: number } }` inline types on `execute`/`run`/`executeSet` (and the inner `executeFn` for `runMigrations`) in favor of the plugin's actual `capSQLiteChanges`. The hand-rolled shape was strictly narrower than the plugin's return type (`Changes.changes` is optional), so every wrapper signature was technically lying.
- `migrate-from-localstorage.ts`: tightens three call sites that fed raw `JSON.parse` results (`unknown[]`) into `bulkInsertEntries`/`bulkReplaceWorkCodes`/`bulkReplaceAttachments`. These are explicit casts because the migration runs once over trusted localStorage written by an earlier version of this app — same pragmatic stance as the `normalize*` helpers in `storageBackup.ts`.

## Why now
Cleanup pass on the latent TS errors. No consumers read the return values of the DB wrappers, so the type drift was invisible until you actually ran `tsc --noEmit`.

## Impact on TypeScript errors
- **Before this PR (vs. main):** 62 errors
- **After:** 55 errors
- **Cluster fully resolved:** `db/database.ts` (4 → 0), `db/migrate-from-localstorage.ts` (3 → 0)

(Note: the commit message contains a typo on the before/after numbers — the correct numbers are above.)

## Test plan
- [x] 758/758 tests pass
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — clean
- [ ] Manual: launch app with no SQLite DB → migrations run successfully and entries appear

## Stacks with
- #22 (BackupAnalysisResult discriminated union) — independent file scopes, can be reviewed/merged in either order

🤖 Generated with [Claude Code](https://claude.com/claude-code)