### PR TITLE
chore(types): fix TS errors in hooks cluster

### DIFF
--- a/src/hooks/actions/useEntryActions.ts
+++ b/src/hooks/actions/useEntryActions.ts
@@ -2,7 +2,7 @@ import React, { useCallback } from "react";
 import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { Haptics, ImpactStyle } from "@capacitor/haptics";
-import type { Entry, UserData, WorkCode, FormState, CalculationConfig } from '../../types';
+import type { Entry, EntryType, UserData, WorkCode, FormState, CalculationConfig } from '../../types';
 import type { Locale } from "../../locales/types";
 import { toLocalDateString } from "../../utils";
 import { parseTime, calculateEntryNetDuration, getTargetMinutesForDate } from "../../utils/timeCalculations";
@@ -92,7 +92,7 @@ export function useEntryActions({
         form.setPauseDuration(isDrive ? 0 : entry.pause ?? 0);
         form.setCode(entry.code ?? getDefaultCode());
         form.setProject(entry.project || "");
-      } else if (specialManual) {
+      } else if (specialManual && entry.start && entry.end) {
         form.setStartTime(entry.start);
         form.setEndTime(entry.end);
         form.setPauseDuration(0);
@@ -203,7 +203,7 @@ export function useEntryActions({
         }
       }
 
-      const storedType = isDrive ? "work" : form.entryType;
+      const storedType: EntryType = isDrive ? "work" : (form.entryType as EntryType);
       const usedCode = isDrive ? WORK_CODE.DRIVE : form.code;
       const usedPause = storedType === "work" ? (isDrive ? 0 : form.pauseDuration) : 0;
       // Im Manual-Modus für Krank/Urlaub/ZA persistieren wir Start/Ende,

--- a/src/hooks/useExport.ts
+++ b/src/hooks/useExport.ts
@@ -46,8 +46,8 @@ export function useExport({ entries, userData, workCodes, attachments = [], expo
   const { t } = useTranslation();
   const [showExportModal, setShowExportModal] = useState(false);
 
-  const buildPayload = async () => {
-    const payload: Record<string, unknown> = {
+  const buildPayload = async (): Promise<BackupPayload> => {
+    const payload: BackupPayload = {
       user: userData,
       entries,
       workCodes,

--- a/src/utils/storageBackup.ts
+++ b/src/utils/storageBackup.ts
@@ -10,7 +10,7 @@ import { getAllEntries } from "../db/repositories/entriesRepo";
 import { replaceFullSnapshot, type ImportSnapshot } from "../db/snapshot";
 import { logger } from "./logger";
 import { getErrorMessage } from "./errorUtils";
-import type { BackupAnalysisResult, BackupAnalysisData, CalculationConfig, UserData, Entry, WorkCode, Attachment } from "../types";
+import type { BackupAnalysisResult, BackupAnalysisData, BackupPayload, CalculationConfig, UserData, Entry, WorkCode, Attachment } from "../types";
 
 // =========================================================
 // BACKUP ORDNER
@@ -67,11 +67,14 @@ export async function computeBackupChecksum(payload: Record<string, unknown> | n
  * Fügt einem Backup-Payload die Felder `formatVersion` und `checksum` hinzu.
  * Mutiert das Objekt und gibt es zur Verkettung zurück.
  */
-export async function attachBackupChecksum(payload: Record<string, unknown> | null): Promise<Record<string, unknown> | null> {
+export async function attachBackupChecksum<T extends BackupPayload | Record<string, unknown>>(
+  payload: T | null
+): Promise<T | null> {
   if (!payload || typeof payload !== "object") return payload;
-  payload.formatVersion = BACKUP_FORMAT_VERSION;
-  const checksum = await computeBackupChecksum(payload);
-  if (checksum) payload.checksum = checksum;
+  const mutable = payload as unknown as Record<string, unknown>;
+  mutable.formatVersion = BACKUP_FORMAT_VERSION;
+  const checksum = await computeBackupChecksum(mutable);
+  if (checksum) mutable.checksum = checksum;
   return payload;
 }
 


### PR DESCRIPTION
## Summary

- **useEntryActions**: cast `form.entryType` (string) to `EntryType` at the boundary, narrow manual-special edit branch on `entry.start && entry.end`
- **useExport**: type `buildPayload` to return `BackupPayload` so `exportPayloadRef.current` assignment typechecks
- **storageBackup**: make `attachBackupChecksum` generic so it preserves the caller's input type (`BackupPayload` or `Record<string, unknown>`) on the return value

Drops TS error count **34 → 29**. The function only mutates `formatVersion` and `checksum`, both already optional fields on `BackupPayload`, so widening the signature is safe and removes the only reason `useExport` was using a loose `Record<string, unknown>`.

## Test plan
- [x] `npx tsc --noEmit` — 5 errors gone, no new ones
- [x] `npx vitest run` — 771/771 pass
- [x] `npm run build` — clean