### PR TITLE
chore(types): fix TS errors in Settings subcomponents

### DIFF
--- a/src/components/Settings/BackupSettings.tsx
+++ b/src/components/Settings/BackupSettings.tsx
@@ -14,6 +14,7 @@ import PlayServicesBanner from "./PlayServicesBanner";
 import { Haptics, ImpactStyle } from "@capacitor/haptics";
 import { Browser } from "@capacitor/browser";
 import { App } from "@capacitor/app";
+import type { PluginListenerHandle } from "@capacitor/core";
 import CollapsibleCard from "./CollapsibleCard";
 import { isSQLiteActive } from "../../db/storageMode";
 import { getSetting, setSetting } from "../../db/repositories/settingsRepo";
@@ -114,8 +115,8 @@ const BackupSettings: React.FC<Props> = ({
   
   // Refs for lifecycle management
   const ncPollInterval = useRef<ReturnType<typeof setInterval> | null>(null);
-  const browserFinishedListener = useRef<{ remove: () => void } | null>(null);
-  const appStateListener = useRef<{ remove: () => void } | null>(null);
+  const browserFinishedListener = useRef<Promise<PluginListenerHandle> | null>(null);
+  const appStateListener = useRef<Promise<PluginListenerHandle> | null>(null);
   const appIsActive = useRef(true);
   const loginAttemptId = useRef<string | null>(null);
 
@@ -257,14 +258,16 @@ const BackupSettings: React.FC<Props> = ({
       ncPollInterval.current = null;
     }
     
-    // Remove listeners
+    // Remove listeners — addListener returns Promise<PluginListenerHandle>,
+    // so the handle may not yet be resolved when cleanup fires. Await it
+    // before calling remove() so we don't leak the registration.
     if (browserFinishedListener.current) {
-      browserFinishedListener.current.remove();
+      void browserFinishedListener.current.then((h) => { void h.remove(); });
       browserFinishedListener.current = null;
     }
-    
+
     if (appStateListener.current) {
-      appStateListener.current.remove();
+      void appStateListener.current.then((h) => { void h.remove(); });
       appStateListener.current = null;
     }
     

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -54,8 +54,10 @@ export interface UserData {
   position: string;
   photo: string | null;
   workDays: number[];       // 7 elements, index 0=Sunday, values in minutes
+  company?: string;         // shown in PDF header, optional profile field
   simpleMode?: boolean;     // nur Aufzeichnung, keine Soll/Ist-Berechnung
   expertMode?: boolean;     // Hausmasta-Modus: erweiterte Einstellungen sichtbar
+  minuteInput?: boolean;    // Hausmasta: Zeitpicker auf Minutenraster (sonst 15-min)
 }
 
 // ─── Calculation Config ──────────────────────────────────────
@@ -292,6 +294,7 @@ export interface GoogleSignInResult {
     accessToken?: string;
   };
   email?: string;
+  givenName?: string;       // optional display label from native Google sign-in
 }
 
 // ─── Backup Analysis ────────────────────────────────────────
@@ -332,6 +335,8 @@ export interface PdfArchiveRunOptions {
   month?: number;
   year?: number;
   force?: boolean;
+  /** Telemetry tag identifying which lifecycle hook triggered the run. */
+  source?: "manual" | "startup" | "resume" | "auto";
 }
 
 // ─── SQL Types ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Add missing optional fields to canonical interfaces so the Settings subcomponents typecheck:

- **`UserData.company`** — shown in PDF header (`ReportPdfDocument`), already set from `ProfileSettings` and `OnboardingWizard`
- **`UserData.minuteInput`** — Hausmasta toggle for 1-min vs 15-min time picker (`DataSettings` + `EntryForm`)
- **`GoogleSignInResult.givenName`** — optional display label returned by the native Google sign-in plugin; `BackupSettings` already falls back to `email`
- **`PdfArchiveRunOptions.source`** — telemetry tag passed by `performRun` callers (`"manual" | "startup" | "resume" | "auto"`)

**`BackupSettings` listener refs**: type as `Promise<PluginListenerHandle>` (matching what `Browser.addListener` / `App.addListener` actually return) and await the promise in cleanup before calling `.remove()`, so we don't leak the registration if cleanup fires before the addListener call resolves.

Drops TS error count **29 → 23**.

## Test plan
- [x] `npx tsc --noEmit` — 6 errors gone, no new ones
- [x] `npx vitest run` — 771/771 pass
- [x] `npm run build` — clean