### PR TITLE
chore(types): drop dead entry.type === "drive" check

### DIFF
--- a/src/utils/timeCalculations.ts
+++ b/src/utils/timeCalculations.ts
@@ -577,7 +577,7 @@ export const recalculateAllEntries = async (
     const hasTime = entry.start && entry.end;
     let expected: number;
 
-    if ((entry.type === "work" || entry.type === "drive" || entry.code === WORK_CODE.DRIVE) && hasTime) {
+    if ((entry.type === "work" || entry.code === WORK_CODE.DRIVE) && hasTime) {
       expected = calculateEntryNetDuration({
         entryType: entry.type,
         startTime: entry.start!,


### PR DESCRIPTION
## Summary

Single-line cleanup: `Entry.type` is `EntryType` (no `"drive"` member), so the third branch of `entry.type === "work" || entry.type === "drive" || entry.code === WORK_CODE.DRIVE` was unreachable. Drive entries are stored as `type: "work"` plus `code: WORK_CODE.DRIVE`, which the surrounding condition already covers. TS flags this as TS2367 (no-overlap comparison).

Drops TS error count **23 → 22**. No behaviour change — the same branch is still selected for drive entries via the code check.

## Test plan
- [x] `npx tsc --noEmit` — TS2367 gone
- [x] `npx vitest run src/utils/__tests__/timeCalculations` — 64/64 pass