### PR TITLE
chore(types): tighten setter prop signatures

### DIFF
--- a/src/components/Onboarding/steps/ProfileStep.tsx
+++ b/src/components/Onboarding/steps/ProfileStep.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { motion } from "framer-motion";
 import { User, Camera, Upload, Building2, Lock } from "lucide-react";
 import { Trans, useTranslation } from "react-i18next";
+import type { WizardFormData } from "../../OnboardingWizard";
 
 /**
  * Onboarding-Schritt 1: Profildaten des Users.
@@ -11,20 +12,9 @@ import { Trans, useTranslation } from "react-i18next";
  * das umgebende System via FileReader.
  */
 
-interface OnboardingFormData {
-  name: string;
-  company: string;
-  role: string;
-  photo: string | null;
-  workDays: number[];
-  autoBackup: boolean;
-  localBackupEnabled: boolean;
-  minuteInput: boolean;
-}
-
 interface Props {
-  formData: OnboardingFormData;
-  setFormData: (data: OnboardingFormData) => void;
+  formData: WizardFormData;
+  setFormData: React.Dispatch<React.SetStateAction<WizardFormData>>;
   photoInputRef: React.RefObject<HTMLInputElement | null>;
   onPhotoUpload: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -36,7 +36,7 @@ const log = logger.scope("Onboarding");
 
 interface Props {
   onComplete: () => void;
-  setUserData: (data: UserData | Record<string, unknown>) => void;
+  setUserData: React.Dispatch<React.SetStateAction<UserData>>;
   importEntries: (entries: Entry[]) => void;
   importWorkCodes: (codes: WorkCode[]) => void;
   setCloudSyncEnabled: (enabled: boolean) => void;
@@ -47,7 +47,7 @@ interface Props {
   setCalculationConfig?: (next: CalculationConfig) => void;
 }
 
-interface FormData {
+export interface WizardFormData {
   name: string;
   company: string;
   role: string;
@@ -86,7 +86,7 @@ const OnboardingWizard: React.FC<Props> = ({ onComplete, setUserData, importEntr
   const [loading, setLoading] = useState(false);
   const [isRestoreFlow, setIsRestoreFlow] = useState(false);
 
-  const [formData, setFormData] = useState<FormData>({
+  const [formData, setFormData] = useState<WizardFormData>({
     name: "",
     company: "",
     role: "",

--- a/src/components/ViewRouter.tsx
+++ b/src/components/ViewRouter.tsx
@@ -50,6 +50,16 @@ interface SettingsRouteProps {
   setLocale: (id: LocaleId) => void;
   setCalculationConfig: (next: CalculationConfig | ((prev: CalculationConfig) => CalculationConfig)) => void;
   resetCalculationConfigToLocale: (newLocale: Locale, workDays: number[]) => void;
+  // Work codes (forwarded to <Settings>)
+  workCodes: WorkCode[];
+  workCodesLoading: boolean;
+  hasAnyWorkCodes: boolean;
+  addWorkCode: (label: string) => boolean;
+  updateWorkCode: (id: number, label: string) => boolean;
+  deleteWorkCode: (id: number) => void;
+  loadWorkCodePreset: (presetId: string) => boolean;
+  availableWorkCodePresets: Array<{ id: string; name: string; description: string; codes: WorkCode[] }>;
+  clearAllWorkCodes: () => void;
 }
 
 interface ViewRouterProps {
@@ -222,7 +232,7 @@ export default function ViewRouter(props: ViewRouterProps) {
                   userData={userData}
                   workCodes={workCodes}
                   attachments={attachments}
-                  readAttachmentFile={readAttachmentFile as (file: Attachment) => Promise<string>}
+                  readAttachmentFile={readAttachmentFile}
                   locale={locale}
                   calculationConfig={calculationConfig}
                   setCalculationConfig={settings.setCalculationConfig}

--- a/src/hooks/useAttachments.ts
+++ b/src/hooks/useAttachments.ts
@@ -301,13 +301,15 @@ export function useAttachments() {
       .slice(0, 6);
   }, [labelSuggestions]);
 
-  const readAttachmentFile = useCallback(async (attachment: Attachment) => {
+  const readAttachmentFile = useCallback(async (attachment: Attachment): Promise<string> => {
     ensureNative();
     const result = await Filesystem.readFile({
       path: attachment.storagePath,
       directory: Directory.Data,
     });
-    return result.data;
+    // Capacitor docs: native returns a base64 string; Blob only happens on web,
+    // and ensureNative() above already excludes the web platform.
+    return result.data as string;
   }, []);
 
   const formatFileSize = useCallback((bytes: number) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,6 +58,7 @@ export interface UserData {
   simpleMode?: boolean;     // nur Aufzeichnung, keine Soll/Ist-Berechnung
   expertMode?: boolean;     // Hausmasta-Modus: erweiterte Einstellungen sichtbar
   minuteInput?: boolean;    // Hausmasta: Zeitpicker auf Minutenraster (sonst 15-min)
+  workModelId?: string;     // Onboarding work-model preset (e.g. "38.5-classic")
 }
 
 // ─── Calculation Config ──────────────────────────────────────

--- a/src/utils/storageBackup.ts
+++ b/src/utils/storageBackup.ts
@@ -464,8 +464,11 @@ export const applyBackup = async (analyzedData: BackupAnalysisData, mode: string
       }
 
       // CalculationConfig aus Backup übernehmen (wenn mode=ALL).
+      // analyzeBackupData liefert das Feld als Record<string, unknown> ohne
+      // strukturelle Validierung — replaceFullSnapshot erwartet CalculationConfig.
+      // Doppel-Cast macht das fehlende Schema-Verifying explizit.
       if (mode === 'ALL' && analyzedData.calculationConfig) {
-        snapshot.calculationConfig = analyzedData.calculationConfig as CalculationConfig;
+        snapshot.calculationConfig = analyzedData.calculationConfig as unknown as CalculationConfig;
       }
 
       await replaceFullSnapshot(snapshot);


### PR DESCRIPTION
## Summary

Five connected fixes that drop the last cluster of non-test TS errors:

- **`useAttachments.readAttachmentFile`** — tighten return to `Promise<string>` (Capacitor docs: native always returns string; `ensureNative()` is called first). Drops the `as` cast in ViewRouter that was working around it.
- **`ViewRouter.SettingsRouteProps`** — add the workCodes-related fields that App already passes through. The `<Settings {...settings}>` spread expected them, but the route-props interface didn't declare them.
- **`OnboardingWizard.setUserData`** — replace the loose `(data: UserData | Record<string, unknown>) => void` with `Dispatch<SetStateAction<UserData>>`, matching what App.tsx hands in. The DEMO and finishSetup callsites already pass valid UserData.
- **`FormData` → `WizardFormData`** — rename + export, then have ProfileStep import it instead of redeclaring a narrower local `OnboardingFormData`. The local interface was missing `localeId, workCodePresetId, calcConfig, customCalc`.
- **`UserData.workModelId`** — lift the field that `demoData` and the Settings intersection patches already rely on.

Plus one leftover from PR #22 (`storageBackup` `applyBackup`): convert the `calculationConfig` cast to `as unknown as CalculationConfig` to make the missing runtime schema check explicit.

Drops TS error count **22 → 17**. All remaining errors are in `__tests__`.

## Test plan
- [x] `npx tsc --noEmit` — 5 prod-code errors gone, no new ones
- [x] `npx vitest run` — 771/771 pass
- [x] `npm run build` — clean