### PR TITLE
chore(types): fix TS errors in hooks tests

### DIFF
--- a/src/hooks/__tests__/useAppState.test.ts
+++ b/src/hooks/__tests__/useAppState.test.ts
@@ -8,6 +8,7 @@ vi.mock("@capacitor/splash-screen", () => ({
 }));
 
 import { useAppState } from "../useAppState";
+import type { SettingsStorageStatus } from "../useSettings";
 import { SplashScreen } from "@capacitor/splash-screen";
 import type { UserData } from "../../types";
 
@@ -50,14 +51,15 @@ describe("useAppState", () => {
 
   it("waits for settings hydration before hiding SplashScreen or showing onboarding", () => {
     const { result, rerender } = renderHook(
-      ({ status }) => useAppState({ userData: NEW_USER, settingsStorageStatus: status }),
-      { initialProps: { status: "loading" as const } },
+      ({ status }: { status: SettingsStorageStatus }) =>
+        useAppState({ userData: NEW_USER, settingsStorageStatus: status }),
+      { initialProps: { status: "loading" } },
     );
 
     expect(result.current.showOnboarding).toBe(false);
     expect(SplashScreen.hide).not.toHaveBeenCalled();
 
-    rerender({ status: "ready" as const });
+    rerender({ status: "ready" });
 
     expect(result.current.showOnboarding).toBe(true);
     expect(SplashScreen.hide).toHaveBeenCalledOnce();

--- a/src/hooks/__tests__/useAutoBackup.test.ts
+++ b/src/hooks/__tests__/useAutoBackup.test.ts
@@ -101,7 +101,7 @@ describe("useAutoBackup", () => {
     vi.clearAllMocks();
     vi.mocked(getValidToken).mockResolvedValue({ accessToken: "test-token" });
     vi.mocked(uploadOrUpdateFile).mockResolvedValue(undefined);
-    vi.mocked(writeBackupFile).mockResolvedValue(undefined);
+    vi.mocked(writeBackupFile).mockResolvedValue(true);
     vi.mocked(getNextcloudAppPassword).mockImplementation(async () => localStorage.getItem("estundnzettl_nextcloud_pass") || "");
     vi.useFakeTimers();
     localStorage.clear();
@@ -372,7 +372,7 @@ describe("useAutoBackup", () => {
 
   it("increments backupFailCount on cloud backup failure", async () => {
     localStorage.setItem("estundnzettl_cloud_sync_enabled", "true");
-    vi.mocked(getValidToken).mockResolvedValueOnce(null);
+    vi.mocked(getValidToken).mockRejectedValueOnce(new Error("AUTH_REQUIRED"));
     const entries = [makeEntry()];
     const { result } = renderHook(() => useAutoBackup(entries, USER, true));
 
@@ -387,7 +387,7 @@ describe("useAutoBackup", () => {
   it("shows error toast when cloud backup fails 5 times", async () => {
     localStorage.setItem("estundnzettl_cloud_sync_enabled", "true");
     localStorage.setItem("estundnzettl_backup_fail_count", "4"); // already 4 failures
-    vi.mocked(getValidToken).mockResolvedValue(null);
+    vi.mocked(getValidToken).mockRejectedValue(new Error("AUTH_REQUIRED"));
     const entries = [makeEntry()];
 
     renderHook(() => useAutoBackup(entries, USER, true));

--- a/src/hooks/__tests__/useSettings.test.ts
+++ b/src/hooks/__tests__/useSettings.test.ts
@@ -72,8 +72,10 @@ describe("useSettings", () => {
     vi.mocked(getSetting).mockResolvedValue(null);
     vi.mocked(setSetting).mockResolvedValue(undefined);
     vi.mocked(deleteSetting).mockResolvedValue(undefined);
-    vi.mocked(deobfuscate).mockImplementation((val: string) => Promise.resolve(val.startsWith("enc:") ? val.replace("enc:", "") : val));
-    vi.mocked(deobfuscateLegacySync).mockImplementation((val: string) => val);
+    vi.mocked(deobfuscate).mockImplementation((val: string | null | undefined) =>
+      Promise.resolve(typeof val === "string" && val.startsWith("enc:") ? val.replace("enc:", "") : (val ?? ""))
+    );
+    vi.mocked(deobfuscateLegacySync).mockImplementation((val: string | null | undefined) => val ?? "");
     secureSecretsMock.store.clear();
     secureSecretsMock.available = true;
     secureSecretsMock.failSet = false;

--- a/src/hooks/actions/__tests__/useEntryActions.test.ts
+++ b/src/hooks/actions/__tests__/useEntryActions.test.ts
@@ -1,5 +1,5 @@
 import type React from "react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 
 // ─── Module-Mocks (VOR Hook-Import) ───────────────────────────
@@ -95,19 +95,22 @@ const makeForm = (overrides: FormStateOverrides = {}): FormState => ({
   startEdit: vi.fn(),
 });
 
+type EntryAction = (entry: Entry) => Promise<void>;
+type EntryActionMock = Mock<EntryAction>;
+
 interface RenderOptions {
   form?: FormState;
   entries?: Entry[];
   userData?: UserData;
   workCodes?: WorkCode[];
-  addEntry?: ReturnType<typeof vi.fn>;
-  updateEntry?: ReturnType<typeof vi.fn>;
+  addEntry?: EntryActionMock;
+  updateEntry?: EntryActionMock;
 }
 
 const renderActions = (opts: RenderOptions = {}) => {
   const form = opts.form ?? makeForm();
-  const addEntry = opts.addEntry ?? vi.fn().mockResolvedValue(undefined);
-  const updateEntry = opts.updateEntry ?? vi.fn().mockResolvedValue(undefined);
+  const addEntry: EntryActionMock = opts.addEntry ?? vi.fn<EntryAction>().mockResolvedValue(undefined);
+  const updateEntry: EntryActionMock = opts.updateEntry ?? vi.fn<EntryAction>().mockResolvedValue(undefined);
   const setView = vi.fn();
   const getDefaultCode = vi.fn(() => 1);
 

--- a/src/hooks/useAppData.ts
+++ b/src/hooks/useAppData.ts
@@ -148,7 +148,7 @@ export function useAppData({ entries, userData, viewMonth, viewYear, allEntries,
     (stats.totalIst / (stats.totalTarget || 1)) * 100
   );
 
-  const lastWorkEntry = useMemo(() => {
+  const lastWorkEntry = useMemo<Entry | null>(() => {
     let latestEntry: Entry | null = null;
 
     entries.forEach((entry) => {

--- a/src/utils/__tests__/storageBackup.test.ts
+++ b/src/utils/__tests__/storageBackup.test.ts
@@ -193,7 +193,7 @@ describe("triggerManualBackup", () => {
       return values[key] ?? null;
     });
     vi.mocked(getNextcloudAppPassword).mockResolvedValue("fixture-secure-pass");
-    vi.mocked(uploadBackup).mockResolvedValue(undefined);
+    vi.mocked(uploadBackup).mockResolvedValue(true);
 
     const result = await triggerManualBackup();
 


### PR DESCRIPTION
## Summary

Six fixes that drop the entire hooks-tests cluster:

- **`useAppData.lastWorkEntry`** — annotate the `useMemo` as `<Entry | null>`. TS narrowed `let latestEntry: Entry | null = null` to `null` and lost the reassignments inside the `forEach` callback, collapsing the return type to `null`.
- **`useAppState.test`** — type renderHook `initialProps` as `{ status: SettingsStorageStatus }` so rerender can pass `"ready"` without `as const` widening.
- **`useAutoBackup.test`** — `writeBackupFile` / `uploadBackup` return `Promise<boolean>`, not `Promise<void>`; switch success mocks to `mockResolvedValue(true)`. The two `getValidToken` `mockResolvedValueOnce(null)` calls switched to `mockRejectedValue(new Error("AUTH_REQUIRED"))` because the real implementation throws on missing token (same pattern already used at line 334).
- **`useSettings.test`** — `deobfuscate` / `deobfuscateLegacySync` take `string | null | undefined`; widen the mock impls and handle the null branch with `?? ""`.
- **`useEntryActions.test`** — type `addEntry` / `updateEntry` as `Mock<(entry: Entry) => Promise<void>>` so they satisfy the hook's real prop signature AND keep `.mock.calls` access.
- **`storageBackup.test`** — same boolean fix as useAutoBackup for `uploadBackup`.

Drops TS error count **17 → 7** (all 10 hooks-test errors). Remaining are component-test issues.

## Test plan
- [x] `npx tsc --noEmit` — 10 errors gone, no new ones
- [x] `npx vitest run` — 771/771 pass