### PR TITLE
ci: gate on tsc --noEmit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Typecheck
+        run: npm run typecheck
+
       - name: Test
         run: npm test
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint . --ext js,jsx,ts,tsx --report-unused-disable-directives",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "coverage": "vitest run --coverage",


### PR DESCRIPTION
## Summary

Lock in the work from PRs #25–#30 (62 → 0 TS errors) by failing CI on TypeScript regressions.

- Add `npm run typecheck` script (one-shot `tsc --noEmit`) so local development and CI run the exact same command
- New CI step between **Lint** and **Test** runs `npm run typecheck`

Placed before Test because TS errors surface faster and give clearer signal than a downstream test failure rooted in a contract drift.

## Test plan
- [x] `npm run typecheck` — passes locally
- [x] CI run on this PR will go through Lint → Typecheck → Test → Build