### PR TITLE
chore(lint): cut ESLint warnings from 67 to 11 (no behaviour change)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -107,6 +107,7 @@ export default defineConfig([
       'no-unused-vars': 'off',
       '@typescript-eslint/no-unused-vars': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-non-null-assertion': 'off',
     },
   },
 ])

--- a/src/components/AppTour.tsx
+++ b/src/components/AppTour.tsx
@@ -14,6 +14,7 @@ import {
   ArrowUp,
   X,
   Hand,
+  type LucideIcon,
 } from "lucide-react";
 
 /**
@@ -38,7 +39,7 @@ import {
 interface TourStepDefinition {
   id: string;
   translationKey: string;      // passt auf appTour.steps.<key>
-  icon: React.ComponentType<any>;
+  icon: LucideIcon;
   color: string;
   target: string | null;
   hasHint?: boolean;

--- a/src/components/AttachmentManager.tsx
+++ b/src/components/AttachmentManager.tsx
@@ -20,7 +20,7 @@ interface Props {
   onClose: () => void;
   entry: Entry | null;
   attachments?: Attachment[];
-  addAttachment: (data: { entryId: number | string; file: File; label: string }) => Promise<any>;
+  addAttachment: (data: { entryId: number | string; file: File; label: string }) => Promise<Attachment>;
   removeAttachment: (attachmentId: string) => Promise<void>;
   getLabelSuggestions: (input: string) => string[];
   formatFileSize: (bytes: number) => string;

--- a/src/components/ChangelogModal.tsx
+++ b/src/components/ChangelogModal.tsx
@@ -76,13 +76,14 @@ const groupBugfixVersions = (data: ChangelogVersion[]): ChangelogVersion[] => {
       continue;
     }
 
-    const group: ChangelogVersion = { ...version, isBugfixGroup: true, groupedVersions: [version] };
+    const groupedVersions: ChangelogVersion[] = [version];
+    const group: ChangelogVersion = { ...version, isBugfixGroup: true, groupedVersions };
     let j = i + 1;
     while (j < data.length) {
       const next = data[j];
       const nextIsBugfixOnly = next.sections?.every((section) => section.iconName === "Bug");
       if (!nextIsBugfixOnly) break;
-      group.groupedVersions!.push(next);
+      groupedVersions.push(next);
       j += 1;
     }
 
@@ -137,8 +138,9 @@ const ChangelogModal = ({ isOpen, onClose }: Props) => {
   };
 
   const renderBugfixGroup = (group: ChangelogVersion, _isFirst: boolean) => {
+    const groupedVersions = group.groupedVersions ?? [];
     const isVersionOpen = !!openVersions[group.version];
-    const count = group.groupedVersions!.length;
+    const count = groupedVersions.length;
 
     return (
       <div key={group.version} className="mb-2">
@@ -176,7 +178,7 @@ const ChangelogModal = ({ isOpen, onClose }: Props) => {
               className="overflow-hidden"
             >
               <div className="pl-8 pt-3 space-y-4">
-                {group.groupedVersions!.map((groupedVersion, index) => (
+                {groupedVersions.map((groupedVersion, index) => (
                   <div key={groupedVersion.version} className={index > 0 ? "pt-2" : ""}>
                     <div className="flex items-center gap-2 mb-1">
                       <span className="text-xs font-semibold text-zinc-500 dark:text-zinc-400">

--- a/src/components/ChangelogModal.tsx
+++ b/src/components/ChangelogModal.tsx
@@ -20,12 +20,13 @@ import {
   BookOpen,
   Layout,
   Palmtree,
+  type LucideIcon,
 } from "lucide-react";
 import { motion, AnimatePresence, useDragControls } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import { getChangelogData } from "../data/changelog-data";
 
-const ICON_MAP: Record<string, React.ComponentType<any>> = {
+const ICON_MAP: Record<string, LucideIcon> = {
   Zap,
   Bug,
   Shield,

--- a/src/components/DecimalDurationPicker.tsx
+++ b/src/components/DecimalDurationPicker.tsx
@@ -47,6 +47,13 @@ const DecimalDurationPicker = ({ isOpen, onClose, initialMinutes, onConfirm, tit
   const [selectedHour, setSelectedHour] = useState(8);
   const [selectedDecimal, setSelectedDecimal] = useState(0);
 
+  const scrollToValue = useCallback((ref: React.RefObject<HTMLDivElement | null>, val: number) => {
+    if (ref.current) {
+      const el = ref.current.querySelector(`[data-value="${val}"]`);
+      if (el) el.scrollIntoView({ block: "center", behavior: "smooth" });
+    }
+  }, []);
+
   useEffect(() => {
     if (isOpen) {
       const { h, d } = getInitialValues(initialMinutes);
@@ -58,14 +65,7 @@ const DecimalDurationPicker = ({ isOpen, onClose, initialMinutes, onConfirm, tit
         scrollToValue(decimalsRef, d);
       }, 100);
     }
-  }, [isOpen, initialMinutes, getInitialValues]);
-
-  const scrollToValue = (ref: React.RefObject<HTMLDivElement | null>, val: number) => {
-    if (ref.current) {
-      const el = ref.current.querySelector(`[data-value="${val}"]`);
-      if (el) el.scrollIntoView({ block: "center", behavior: "smooth" });
-    }
-  };
+  }, [isOpen, initialMinutes, getInitialValues, scrollToValue]);
 
   const hours = Array.from({ length: 25 }, (_, i) => i);
   

--- a/src/components/EntryForm.tsx
+++ b/src/components/EntryForm.tsx
@@ -339,7 +339,7 @@ const EntryForm: React.FC<Props> = ({
               <div className="flex-1">
                 <DatePicker
                   selected={new Date(formDate)}
-                  onChange={(date: Date | null) => setFormDate(toLocalDateString(date!))}
+                  onChange={(date: Date | null) => { if (date) setFormDate(toLocalDateString(date)); }}
                   onMonthChange={(date) => setViewYear(date.getFullYear())}
                   onYearChange={(date) => setViewYear(date.getFullYear())}
                   dateFormat="eee, dd.MM.yyyy" 

--- a/src/components/LiveTimerOverlay.tsx
+++ b/src/components/LiveTimerOverlay.tsx
@@ -36,11 +36,12 @@ const LiveTimerOverlay = ({
   const fabRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
-    if (!timerState.isRunning) return;
+    if (!timerState.isRunning || !timerState.startTime) return;
 
+    const startTime = timerState.startTime;
     const update = () => {
       const now = new Date();
-      const start = new Date(timerState.startTime!);
+      const start = new Date(startTime);
 
       let currentPause = 0;
       if (timerState.isPaused && timerState.pauseStartTime) {

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -337,7 +337,7 @@ const OnboardingWizard: React.FC<Props> = ({ onComplete, setUserData, importEntr
       ncSetupPollRef.current = setInterval(async () => {
         attempts++;
         if (attempts > 100) {
-          clearInterval(ncSetupPollRef.current!);
+          if (ncSetupPollRef.current) clearInterval(ncSetupPollRef.current);
           ncSetupPollRef.current = null;
           setNcSetupConnecting(false);
           toast.error(t("onboarding.toast.ncTimeout"));

--- a/src/components/Settings/BackupSettings.tsx
+++ b/src/components/Settings/BackupSettings.tsx
@@ -358,7 +358,7 @@ const BackupSettings: React.FC<Props> = ({
       
       if (attempts > maxAttempts) {
         log.debug('Polling timeout');
-        clearInterval(ncPollInterval.current!);
+        if (ncPollInterval.current) clearInterval(ncPollInterval.current);
         ncPollInterval.current = null;
         setNcConnecting(false);
         toast.error(t("settings.backup.toast.pollingTimeout"));
@@ -378,7 +378,7 @@ const BackupSettings: React.FC<Props> = ({
 
         if (result.status === 'complete') {
           log.debug('Login complete!');
-          clearInterval(ncPollInterval.current!);
+          if (ncPollInterval.current) clearInterval(ncPollInterval.current);
           ncPollInterval.current = null;
 
           const serverUrl = (result.server as string).replace(/\/+$/, '');
@@ -386,7 +386,7 @@ const BackupSettings: React.FC<Props> = ({
         }
       } catch (error) {
         log.error('Polling error:', error);
-        clearInterval(ncPollInterval.current!);
+        if (ncPollInterval.current) clearInterval(ncPollInterval.current);
         ncPollInterval.current = null;
         setNcConnecting(false);
         toast.error((error as Error)?.message || t("settings.backup.toast.nextcloudLoginFailed"));

--- a/src/components/Settings/ProfileSettings.tsx
+++ b/src/components/Settings/ProfileSettings.tsx
@@ -25,8 +25,13 @@ const ProfileSettings: React.FC<Props> = ({ userData, setUserData }) => {
       const reader = new FileReader();
       reader.readAsDataURL(file);
       reader.onload = (event) => {
+        const result = event.target?.result;
+        if (typeof result !== "string") {
+          reject(new Error("FileReader result is not a string"));
+          return;
+        }
         const img = new Image();
-        img.src = event.target!.result as string;
+        img.src = result;
         img.onload = () => {
           const MAX_WIDTH = 1024;
           const MAX_HEIGHT = 1024;
@@ -40,7 +45,11 @@ const ProfileSettings: React.FC<Props> = ({ userData, setUserData }) => {
           const canvas = document.createElement("canvas");
           canvas.width = width;
           canvas.height = height;
-          const ctx = canvas.getContext("2d")!;
+          const ctx = canvas.getContext("2d");
+          if (!ctx) {
+            reject(new Error("Canvas 2D context not available"));
+            return;
+          }
           ctx.drawImage(img, 0, 0, width, height);
           resolve(canvas.toDataURL("image/jpeg", 0.9));
         };

--- a/src/components/WorkCodeManager.tsx
+++ b/src/components/WorkCodeManager.tsx
@@ -74,7 +74,8 @@ export const WorkCodeManager = ({
   };
 
   const handleSaveEdit = () => {
-    if (updateCode(editingId!, editingLabel)) {
+    if (editingId === null) return;
+    if (updateCode(editingId, editingLabel)) {
       setEditingId(null);
       setEditingLabel('');
     }

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -104,6 +104,12 @@ export async function getDb(): Promise<string | null> {
   return ok ? DB_NAME : null;
 }
 
+async function getDbOrThrow(): Promise<string> {
+  const db = await getDb();
+  if (!db) throw new Error("[db] SQLite ist nicht verfügbar – init() fehlgeschlagen oder noch nicht aufgerufen");
+  return db;
+}
+
 /**
  * Prüft ob SQLite bereits als verfügbar initialisiert wurde (synchron).
  * Gibt true/false/null zurück (null = noch nicht initialisiert).
@@ -132,16 +138,16 @@ export async function closeDb(): Promise<void> {
  * Raw execute — führt beliebiges SQL aus (DDL, multi-statement).
  */
 export async function execute(sql: string): Promise<capSQLiteChanges> {
-  const db = await getDb();
-  return CapacitorSQLite.execute({ database: db!, statements: sql });
+  const db = await getDbOrThrow();
+  return CapacitorSQLite.execute({ database: db, statements: sql });
 }
 
 /**
  * Raw run — einzelnes Statement mit Parametern (INSERT/UPDATE/DELETE).
  */
 export async function run(sql: string, values: SqlValue[] = []): Promise<capSQLiteChanges> {
-  const db = await getDb();
-  return CapacitorSQLite.run({ database: db!, statement: sql, values });
+  const db = await getDbOrThrow();
+  return CapacitorSQLite.run({ database: db, statement: sql, values });
 }
 
 /**
@@ -151,16 +157,16 @@ export async function run(sql: string, values: SqlValue[] = []): Promise<capSQLi
  */
 export async function executeSet(set: Array<{ statement: string; values: SqlValue[] }>, transaction: boolean = true): Promise<capSQLiteChanges | void> {
   if (!set || set.length === 0) return;
-  const db = await getDb();
-  return CapacitorSQLite.executeSet({ database: db!, set, transaction });
+  const db = await getDbOrThrow();
+  return CapacitorSQLite.executeSet({ database: db, set, transaction });
 }
 
 /**
  * Raw query — SELECT mit Parametern.
  */
 export async function query<T extends Record<string, unknown> = Record<string, unknown>>(sql: string, values: SqlValue[] = []): Promise<T[]> {
-  const db = await getDb();
-  const result = await CapacitorSQLite.query({ database: db!, statement: sql, values });
+  const db = await getDbOrThrow();
+  const result = await CapacitorSQLite.query({ database: db, statement: sql, values });
   return (result.values || []) as T[];
 }
 
@@ -175,15 +181,15 @@ export async function query<T extends Record<string, unknown> = Record<string, u
  * Transaktionen ohne SAVEPOINT.
  */
 export async function transaction<T>(fn: () => Promise<T>): Promise<T> {
-  const db = await getDb();
-  await CapacitorSQLite.execute({ database: db!, statements: "BEGIN TRANSACTION;" });
+  const db = await getDbOrThrow();
+  await CapacitorSQLite.execute({ database: db, statements: "BEGIN TRANSACTION;" });
   try {
     const result = await fn();
-    await CapacitorSQLite.execute({ database: db!, statements: "COMMIT;" });
+    await CapacitorSQLite.execute({ database: db, statements: "COMMIT;" });
     return result;
   } catch (err) {
     try {
-      await CapacitorSQLite.execute({ database: db!, statements: "ROLLBACK;" });
+      await CapacitorSQLite.execute({ database: db, statements: "ROLLBACK;" });
     } catch (rollbackErr) {
       logger.error("[db] ROLLBACK fehlgeschlagen", rollbackErr);
     }

--- a/src/hooks/actions/useDeleteActions.ts
+++ b/src/hooks/actions/useDeleteActions.ts
@@ -35,9 +35,10 @@ export function useDeleteActions({
   const executeDelete = useCallback(
     async (deleteTarget: DeleteTarget | null) => {
       if (deleteTarget?.type === "single") {
-        await deleteEntry(deleteTarget.id!);
+        if (deleteTarget.id === undefined) return;
+        await deleteEntry(deleteTarget.id);
         if (removeAttachmentsForEntry) {
-          await removeAttachmentsForEntry(deleteTarget.id!);
+          await removeAttachmentsForEntry(deleteTarget.id);
         }
         toast.success(t("toasts.entry.deleted"));
       } else if (deleteTarget?.type === "all") {

--- a/src/hooks/useAppData.ts
+++ b/src/hooks/useAppData.ts
@@ -170,8 +170,8 @@ export function useAppData({ entries, userData, viewMonth, viewYear, allEntries,
 
   const uniqueProjects = useMemo(() => {
     const projects = entries
-      .filter((entry) => entry.type === "work" && entry.project?.trim())
-      .map((entry) => entry.project!.trim());
+      .filter((entry): entry is Entry & { project: string } => entry.type === "work" && !!entry.project?.trim())
+      .map((entry) => entry.project.trim());
 
     return [...new Set(projects)].sort();
   }, [entries]);

--- a/src/hooks/useAttachments.ts
+++ b/src/hooks/useAttachments.ts
@@ -30,7 +30,9 @@ const sanitizeFileName = (name: string = "dokument"): string => {
 
 const getExtension = (fileName: string = ""): string => {
   const parts = fileName.split(".");
-  return parts.length > 1 ? parts.pop()!.toLowerCase() : "bin";
+  if (parts.length <= 1) return "bin";
+  const ext = parts.pop();
+  return ext ? ext.toLowerCase() : "bin";
 };
 
 const ensureNative = (): void => {

--- a/src/hooks/useLiveTimer.ts
+++ b/src/hooks/useLiveTimer.ts
@@ -138,9 +138,9 @@ export const useLiveTimer = () => {
   };
 
   const resumeTimer = () => {
-    if (!timerState.isPaused) return;
+    if (!timerState.isPaused || !timerState.pauseStartTime) return;
     const now = new Date();
-    const pauseStart = new Date(timerState.pauseStartTime!);
+    const pauseStart = new Date(timerState.pauseStartTime);
     const pauseDiffMs = now.getTime() - pauseStart.getTime();
 
     setTimerState(prev => ({

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,7 +9,10 @@ import './index.css'
 // Initialize Sentry in production (no-op without DSN)
 initSentry();
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+const rootElement = document.getElementById('root');
+if (!rootElement) throw new Error('Root element "#root" not found in index.html');
+
+ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
     <ErrorBoundary>
       <App />

--- a/src/utils/nextcloudClient.ts
+++ b/src/utils/nextcloudClient.ts
@@ -100,7 +100,7 @@ export async function initiateLoginFlow(serverUrl: string): Promise<NcResult> {
 
   if (Capacitor.getPlatform() === 'android') {
     try {
-      return await NextcloudLoginFlow.startLoginFlow({ serverUrl: normalized.value as string } as any) as unknown as NcResult;
+      return await NextcloudLoginFlow.startLoginFlow({ serverUrl: normalized.value as string }) as unknown as NcResult;
     } catch (error) {
       return buildError('PLUGIN_ERROR', getErrorMessage(error, 'Native Android-Integration fehlgeschlagen'), undefined, true);
     }

--- a/src/utils/nextcloudClient.ts
+++ b/src/utils/nextcloudClient.ts
@@ -311,9 +311,8 @@ export async function resolveUserId(serverUrl: string, loginName: string, appPas
 
 async function getDavUser(serverUrl: string, authUser: string, appPassword: string): Promise<string> {
   const cacheKey = getDavUserCacheKey(serverUrl, authUser);
-  if (resolvedDavUserCache.has(cacheKey)) {
-    return resolvedDavUserCache.get(cacheKey)!;
-  }
+  const cached = resolvedDavUserCache.get(cacheKey);
+  if (cached !== undefined) return cached;
 
   const davUser = await resolveUserId(serverUrl, authUser, appPassword);
   resolvedDavUserCache.set(cacheKey, davUser || authUser);

--- a/src/utils/storageBackup.ts
+++ b/src/utils/storageBackup.ts
@@ -316,7 +316,12 @@ export const readJsonFile = (file: File): Promise<unknown> => {
     const reader = new FileReader();
     reader.onload = (e: ProgressEvent<FileReader>) => {
       try {
-        const json = JSON.parse(e.target!.result as string);
+        const result = e.target?.result;
+        if (typeof result !== "string") {
+          reject(new Error("FileReader result is not a string"));
+          return;
+        }
+        const json = JSON.parse(result);
         resolve(json);
       } catch (err) {
         reject(err);

--- a/src/utils/timeCalculations.ts
+++ b/src/utils/timeCalculations.ts
@@ -574,14 +574,13 @@ export const recalculateAllEntries = async (
   let fixed = 0;
 
   for (const entry of entries) {
-    const hasTime = entry.start && entry.end;
     let expected: number;
 
-    if ((entry.type === "work" || entry.code === WORK_CODE.DRIVE) && hasTime) {
+    if ((entry.type === "work" || entry.code === WORK_CODE.DRIVE) && entry.start && entry.end) {
       expected = calculateEntryNetDuration({
         entryType: entry.type,
-        startTime: entry.start!,
-        endTime: entry.end!,
+        startTime: entry.start,
+        endTime: entry.end,
         pauseDuration: entry.pause ?? 0,
         formDate: entry.date,
         userData,
@@ -589,12 +588,12 @@ export const recalculateAllEntries = async (
         locale,
         config,
       });
-    } else if ((entry.type === "vacation" || entry.type === "sick" || entry.type === "time_comp") && hasTime) {
+    } else if ((entry.type === "vacation" || entry.type === "sick" || entry.type === "time_comp") && entry.start && entry.end) {
       // Special entries with manual start/end
       expected = calculateEntryNetDuration({
         entryType: entry.type,
-        startTime: entry.start!,
-        endTime: entry.end!,
+        startTime: entry.start,
+        endTime: entry.end,
         pauseDuration: 0,
         formDate: entry.date,
         userData,


### PR DESCRIPTION
## Summary

Stepwise lint cleanup — every commit keeps `tsc` clean and all 771 tests green.

| Stage | Warnings |
|-------|----------|
| Baseline | 67 |
| 1. Auto-fixes (no-explicit-any, react-hooks/immutability) | 63 |
| 2. Disable `no-non-null-assertion` for test files (matches existing relaxed rules) | 42 |
| 3. Four production hot-spots fixed by pattern | 25 |
| 4. Remaining 14 scattered non-null assertions removed | **11** |

Remaining 11 warnings are all `react-hooks/set-state-in-effect` — actual hook anti-patterns that need individual refactor decisions; deferred to a follow-up branch.

## Commits

- **fix no-explicit-any (4x) and react-hooks/immutability (1x)** — `React.ComponentType<any>` → `LucideIcon`, `Promise<any>` → `Promise<Attachment>`, drop redundant `as any`, wrap `scrollToValue` in `useCallback` before its effect.
- **relax no-non-null-assertion for test files** — single config line; test files already disable other noisy rules.
- **remove non-null assertions from four production hot-spots** — `db/database.ts` (7×, new `getDbOrThrow()` helper), `timeCalculations.ts` (4×, direct narrowing), `BackupSettings.tsx` (3×, null-check), `ChangelogModal.tsx` (3×, local const).
- **remove remaining 14 scattered non-null assertions** — each fix is local and minimal; covers `main.tsx`, `EntryForm`, `LiveTimerOverlay`, `OnboardingWizard`, `ProfileSettings`, `WorkCodeManager`, `useDeleteActions`, `useAppData`, `useAttachments`, `useLiveTimer`, `nextcloudClient`, `storageBackup`.

## Test plan

- [x] `npm run lint` — 67 → 11 warnings, 0 errors
- [x] `npm run typecheck` — 0 errors
- [x] `npm test` — 771/771 passing
- [ ] Manual smoke test in app (DB ops, Nextcloud setup polling, attachments, decimal duration picker)

https://claude.ai/code/session_01DreTvRMVVkydbyoVudmhtm

---
_Generated by [Claude Code](https://claude.ai/code/session_01DreTvRMVVkydbyoVudmhtm)_