### PR TITLE
chore: bump version to 4.3.3

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "com.estundnzettl.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 270
-        versionName "4.3.2"
+        versionCode 271
+        versionName "4.3.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eStundnzettl",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eStundnzettl",
-      "version": "4.3.2",
+      "version": "4.3.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eStundnzettl",
   "private": true,
-  "version": "4.3.2",
+  "version": "4.3.3",
   "type": "module",
   "description": "Elektronischer Stundenzettel — smarte Zeiterfassung aus der Steiermark (Ionic/Capacitor App).",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bump version 4.3.2 → 4.3.3.

- `package.json` + `package-lock.json`: `4.3.2` → `4.3.3`
- `android/app/build.gradle`: `versionCode 270 → 271`, `versionName "4.3.3"`

Changelog entries in `src/data/changelog-data.*.ts` and `docs/play-store-listing.md` are historical 4.3.2 records — left untouched. Fastlane changelog files for the new versionCode can be added later when preparing the actual release.

## Test plan

- [x] `npm install` runs clean
- [ ] App builds with new version

https://claude.ai/code/session_01DreTvRMVVkydbyoVudmhtm

---
_Generated by [Claude Code](https://claude.ai/code/session_01DreTvRMVVkydbyoVudmhtm)_