### PR TITLE
chore: remove low-risk unused imports

### DIFF
--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { AlertTriangle, X } from "lucide-react";
-import { motion, AnimatePresence } from "framer-motion";
+import { AlertTriangle } from "lucide-react";
+import { motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
 
 interface Props {

--- a/src/components/ImportConflictModal.tsx
+++ b/src/components/ImportConflictModal.tsx
@@ -1,6 +1,5 @@
-import React from "react";
-import { Import, AlertTriangle, Check, X, Calendar, User } from "lucide-react";
-import { motion, AnimatePresence } from "framer-motion";
+import { Import, AlertTriangle, Check, Calendar, User } from "lucide-react";
+import { motion } from "framer-motion";
 import { Trans, useTranslation } from "react-i18next";
 
 interface AnalysisData {

--- a/src/components/SkeletonScreen.tsx
+++ b/src/components/SkeletonScreen.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 /**
  * Einfacher Skeleton-Fallback für React.lazy / Suspense.
  * Respektiert das aktuelle Theme (die .dark-Klasse wird auf <html> gesetzt).


### PR DESCRIPTION
## Summary

- Removes unused React/import symbols from `SkeletonScreen`, `ConfirmModal`, and `ImportConflictModal`.
- Keeps scope intentionally small for Issue #36 low-risk cleanup.
- Does not touch backup, storage, Nextcloud, Google Drive, workflow, architecture, or a11y/button behavior.

Refs #36.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test` (64 files, 771 tests passed)
- `npm run build` (passes; existing large chunk warning only)