### PR TITLE
docs(readme): polish badges — fix license, add CI + Codacy, reorder

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -4,6 +4,24 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/D3rPaPaH0d3n/eStundnzettl/releases/latest">
+    <img src="https://img.shields.io/github/v/release/D3rPaPaH0d3n/eStundnzettl?label=Version&color=10b981&style=for-the-badge&logo=github&logoColor=white" alt="Latest version" />
+  </a>
+  <a href="https://github.com/D3rPaPaH0d3n/eStundnzettl/releases">
+    <img src="https://img.shields.io/github/downloads/D3rPaPaH0d3n/eStundnzettl/total?label=Downloads&color=8b5cf6&style=for-the-badge&logo=github&logoColor=white" alt="GitHub downloads" />
+  </a>
+  <a href="https://github.com/D3rPaPaH0d3n/eStundnzettl/blob/main/LICENSE">
+    <img src="https://img.shields.io/badge/License-MIT-blue?style=for-the-badge" alt="License MIT" />
+  </a>
+  <a href="https://github.com/D3rPaPaH0d3n/eStundnzettl/actions/workflows/ci.yml">
+    <img src="https://github.com/D3rPaPaH0d3n/eStundnzettl/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI Status" />
+  </a>
+  <a href="https://app.codacy.com/gh/D3rPaPaH0d3n/eStundnzettl/dashboard">
+    <img src="https://app.codacy.com/project/badge/Grade/85110d7924544b05a47c2dc3fada1371" alt="Codacy Code Quality" />
+  </a>
+</p>
+
+<p align="center">
   <img src="https://raw.githubusercontent.com/D3rPaPaH0d3n/eStundnzettl/main/android/app/src/main/res/mipmap-xxxhdpi/ic_launcher_foreground.webp" width="120" alt="eStundnzettl logo" />
 </p>
 
@@ -13,18 +31,6 @@
   <strong>🏔️ Smart time tracking from Styria, Austria.</strong><br />
   No more paper slips — log hours, drives and vacation straight from your phone.<br />
   At the end of the month: one clean PDF. Done. ✅
-</p>
-
-<p align="center">
-  <a href="https://github.com/D3rPaPaH0d3n/eStundnzettl/releases/latest">
-    <img src="https://img.shields.io/github/v/release/D3rPaPaH0d3n/eStundnzettl?label=Version&color=10b981&style=for-the-badge&logo=github&logoColor=white" alt="Latest version" />
-  </a>
-  <a href="https://github.com/D3rPaPaH0d3n/eStundnzettl/releases">
-    <img src="https://img.shields.io/github/downloads/D3rPaPaH0d3n/eStundnzettl/total?label=Downloads&color=8b5cf6&style=for-the-badge&logo=github&logoColor=white" alt="GitHub downloads" />
-  </a>
-  <a href="https://github.com/D3rPaPaH0d3n/eStundnzettl/blob/main/LICENSE">
-    <img src="https://img.shields.io/github/license/D3rPaPaH0d3n/eStundnzettl?label=License&color=64748b&style=for-the-badge" alt="License" />
-  </a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -4,6 +4,24 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/D3rPaPaH0d3n/eStundnzettl/releases/latest">
+    <img src="https://img.shields.io/github/v/release/D3rPaPaH0d3n/eStundnzettl?label=Version&color=10b981&style=for-the-badge&logo=github&logoColor=white" alt="Aktuelle Version" />
+  </a>
+  <a href="https://github.com/D3rPaPaH0d3n/eStundnzettl/releases">
+    <img src="https://img.shields.io/github/downloads/D3rPaPaH0d3n/eStundnzettl/total?label=Downloads&color=8b5cf6&style=for-the-badge&logo=github&logoColor=white" alt="GitHub-Downloads" />
+  </a>
+  <a href="https://github.com/D3rPaPaH0d3n/eStundnzettl/blob/main/LICENSE">
+    <img src="https://img.shields.io/badge/Lizenz-MIT-blue?style=for-the-badge" alt="Lizenz MIT" />
+  </a>
+  <a href="https://github.com/D3rPaPaH0d3n/eStundnzettl/actions/workflows/ci.yml">
+    <img src="https://github.com/D3rPaPaH0d3n/eStundnzettl/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI Status" />
+  </a>
+  <a href="https://app.codacy.com/gh/D3rPaPaH0d3n/eStundnzettl/dashboard">
+    <img src="https://app.codacy.com/project/badge/Grade/85110d7924544b05a47c2dc3fada1371" alt="Codacy Code Quality" />
+  </a>
+</p>
+
+<p align="center">
   <img src="https://raw.githubusercontent.com/D3rPaPaH0d3n/eStundnzettl/main/android/app/src/main/res/mipmap-xxxhdpi/ic_launcher_foreground.webp" width="120" alt="eStundnzettl Logo" />
 </p>
 
@@ -13,18 +31,6 @@
   <strong>🏔️ Die smarte Zeiterfassung aus der Steiermark.</strong><br />
   Schluss mit Zettelwirtschaft — Stunden, Fahrten und Urlaub direkt am Handy erfassen.<br />
   Am Monatsende ein sauberes PDF. Fertig. ✅
-</p>
-
-<p align="center">
-  <a href="https://github.com/D3rPaPaH0d3n/eStundnzettl/releases/latest">
-    <img src="https://img.shields.io/github/v/release/D3rPaPaH0d3n/eStundnzettl?label=Version&color=10b981&style=for-the-badge&logo=github&logoColor=white" alt="Aktuelle Version" />
-  </a>
-  <a href="https://github.com/D3rPaPaH0d3n/eStundnzettl/releases">
-    <img src="https://img.shields.io/github/downloads/D3rPaPaH0d3n/eStundnzettl/total?label=Downloads&color=8b5cf6&style=for-the-badge&logo=github&logoColor=white" alt="GitHub-Downloads" />
-  </a>
-  <a href="https://github.com/D3rPaPaH0d3n/eStundnzettl/blob/main/LICENSE">
-    <img src="https://img.shields.io/github/license/D3rPaPaH0d3n/eStundnzettl?label=Lizenz&color=64748b&style=for-the-badge" alt="Lizenz" />
-  </a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

Three small README polish items:

1. **Fix "Invalid" license badge** — replace the dynamic `shields.io/github/license` badge (which renders "Invalid" because GitHub's auto-detection can fail) with a static MIT badge.
2. **Reorder badges** — move all status badges (Version, Downloads, License, CI, Codacy) into one group directly below the language switch; the logo now sits cleanly below the badges instead of being sandwiched between language switch and badges.
3. **Add code quality badges** — GitHub Actions CI status (`ci.yml`) and Codacy grade (project `85110d7924544b05a47c2dc3fada1371`).

README.en.md mirrors the same structure with English labels.

The donation link (`https://revolut.me/mkainer/pocket/QAt1Q0Ntsb`) was already identical in README, README.en and `AppInfoSettings.tsx` — left untouched.

## Test plan

- [ ] GitHub PR preview shows all badges rendering (no "Invalid")
- [ ] License badge reads "Lizenz: MIT" / "License: MIT" in blue
- [ ] CI badge shows "passing" (green)
- [ ] Codacy badge shows a grade letter
- [ ] Logo appears below the badge row, not between it and the language switch
- [ ] Badge clicks lead to the right URLs (LICENSE, Actions, Codacy dashboard)

https://claude.ai/code/session_01DreTvRMVVkydbyoVudmhtm

---
_Generated by [Claude Code](https://claude.ai/code/session_01DreTvRMVVkydbyoVudmhtm)_