### PR TITLE
chore: trim tiny unused type exports

### DIFF
--- a/src/components/DashboardMonthPicker.tsx
+++ b/src/components/DashboardMonthPicker.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import DatePicker, { registerLocale } from "react-datepicker";
-// @ts-ignore
 import "react-datepicker/dist/react-datepicker.css";
 import { de, enUS } from "date-fns/locale";
 import { getDatePickerLocale } from "../utils/formatLocale";

--- a/src/components/EntryForm.tsx
+++ b/src/components/EntryForm.tsx
@@ -8,7 +8,6 @@ import { Haptics, ImpactStyle } from "@capacitor/haptics";
 import { useTranslation } from "react-i18next";
 
 import DatePicker, { registerLocale, CalendarContainer } from "react-datepicker";
-// @ts-ignore
 import "react-datepicker/dist/react-datepicker.css";
 import { de, enUS } from "date-fns/locale";
 import { getDatePickerLocale } from "../utils/formatLocale";

--- a/src/hooks/useLocaleSetting.ts
+++ b/src/hooks/useLocaleSetting.ts
@@ -63,5 +63,3 @@ export function useLocaleSetting() {
 
   return { language, setLanguage, supportedLanguages: SUPPORTED_LANGUAGES };
 }
-
-export type UseLocaleSettingReturn = ReturnType<typeof useLocaleSetting>;

--- a/src/hooks/useUpdateAvailable.ts
+++ b/src/hooks/useUpdateAvailable.ts
@@ -54,7 +54,7 @@ interface ReleaseApiPayload {
   prerelease?: boolean;
 }
 
-export interface UpdateAvailableState {
+interface UpdateAvailableState {
   /** True when a newer-than-installed release was found AND not dismissed. */
   available: boolean;
   /** Tag string of the newer release ("v4.3.0"). */

--- a/src/hooks/useWhatsNewModal.ts
+++ b/src/hooks/useWhatsNewModal.ts
@@ -22,7 +22,7 @@ const STORAGE_KEY = "last_seen_app_version";
  *   - Dev-Builds (`APP_VERSION === 'dev'`): kein Popup, damit lokale
  *     Vite-Sessions nicht ständig auftauchen.
  */
-export interface WhatsNewState {
+interface WhatsNewState {
   /** True genau einmal: nach erfolgreicher Versionsänderung. */
   shouldShow: boolean;
   /** Aufrufen wenn der User das Modal geschlossen hat. */


### PR DESCRIPTION
## Summary\n- remove unnecessary ts-ignore comments before CSS imports\n- stop exporting unused hook state/type helpers\n\n## Validation\n- npm run lint\n- npm run typecheck\n\nLow-risk cleanup only; no behavior, release/version, lockfile, database, or migration changes.