### PR TITLE
docs(readme): refresh content to reflect app state in 4.3.3

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -82,13 +82,18 @@
 |---|---------|--------------|
 | 🎯 | **Flexible work schedules** | 38.5h, 40h, 4-day week or fully custom |
 | ⏱️ | **Live timer** | Long-press, swipe up — timer running |
+| 🎙️ | **Voice input** | Dictate entries — German speech parser included |
 | 📊 | **Real-time balance** | Overtime, extra hours and flex-time always in view |
+| 🇦🇹 | **Regional holidays** | Austria, 16 German states and 26 Swiss cantons |
 | 📄 | **PDF export** | Professional timesheet by month or week |
 | ☁️ | **Automatic backups** | Google Drive, Nextcloud or local — daily |
 | 📎 | **Attach documents** | Delivery notes, photos and receipts straight on the entry |
+| 📴 | **Offline-capable** | Works fully without internet — cloud is optional |
+| 🚫 | **No tracking** | No ads, no analytics, no data collection |
+| 🌍 | **Bilingual** | German & English UI — language switchable in Settings |
+| 🧭 | **Onboarding & tour** | Guided setup + interactive in-app tour on first launch |
 | 🌙 | **Dark mode** | Easy on the eyes when it's dark outside |
 | 🔧 | **Power-user mode** | Advanced settings for pros — opt-in |
-| 🌐 | **Bilingual** | Full German and English UI — picker in settings |
 
 ---
 
@@ -156,8 +161,11 @@ For pros who want more! Enable **power-user mode** in settings to unlock extra f
 - 🖥️ **Nextcloud integration** — back up to your own cloud
 - 📦 **JSON import / export** — back up and move data manually
 - 📄 **Automatic PDF archive** — monthly PDF backups to every target
+- 🎛️ **PDF layout toggles** — choose which fields appear in the exported PDF
 - ⏱️ **Minute mode** — 1-minute instead of 15-minute steps
 - 🏷️ **Activity codes** — industry presets or your own codes
+- 🌍 **Locale picker** — state/canton for correct holidays & calculation
+- ⏸️ **Auto-break rules** — configurable break logic per work type and locale
 - 📋 **Record only** — hour tracking without target/actual calculation
 
 ---
@@ -182,7 +190,10 @@ The app UI ships with full **German and English** translations. Settings → **L
 
 - 🔒 **Local first:** All data stays on your device
 - 💾 **Backups:** Optional — local, Google Drive or Nextcloud
+- 🔐 **Secure passwords:** Nextcloud credentials live in Android Secure Storage, not in localStorage
+- 🩹 **Anonymous crash reporting:** Sentry only reports actual crashes, opt-out, no input or user data
 - 🚫 **No tracking:** No ads, no analytics, no data collection
+- 📖 **Open source:** Full source code available, MIT-licensed
 - ✅ **Full control:** You decide where your data goes
 
 ---
@@ -209,11 +220,14 @@ If you find it useful and feel like saying thanks, a small tip via Revolut is al
 | | Technology |
 |---|-------------|
 | 🖥️ Frontend | TypeScript, React, Vite |
-| 📱 Mobile | Capacitor (Android) |
+| 🎨 UI | Tailwind CSS 4, Framer Motion, Lucide Icons |
+| 📱 Mobile | Capacitor (Android), Capacitor Secure Storage |
 | 🗄️ Database | SQLite (domain data), localStorage only for UI/cache/legacy migration |
-| 📄 PDF | @react-pdf/renderer (vector, searchable) |
+| 📄 PDF | @react-pdf/renderer (vector, searchable), pdfjs-dist (preview) |
 | ☁️ Cloud | Google Drive API, Nextcloud WebDAV |
-| 🌐 i18n | i18next + react-i18next |
+| 🌐 i18n | i18next + react-i18next (German & English) |
+| 🔍 Validation | Zod (backup schemas, import validation) |
+| 🛡️ Monitoring | Sentry (anonymous crash reporting, opt-out) |
 | 🧪 Tests | Vitest |
 
 ---

--- a/README.md
+++ b/README.md
@@ -82,10 +82,16 @@
 |---|---------|--------------|
 | 🎯 | **Flexible Arbeitszeitmodelle** | 38,5h, 40h, 4-Tage-Woche oder komplett individuell |
 | ⏱️ | **Live-Timer** | Lang drücken, nach oben wischen — Timer läuft |
+| 🎙️ | **Sprachsteuerung** | Eintrag per Spracheingabe diktieren — Deutsch-Parser inklusive |
 | 📊 | **Echtzeit-Saldo** | Überstunden, Mehrarbeit und Gleitzeit immer im Blick |
+| 🇦🇹 | **Lokale Feiertage** | Österreich, 16 deutsche Bundesländer und 26 Schweizer Kantone |
 | 📄 | **PDF-Export** | Professioneller Stundenzettel per Monats- oder Wochenansicht |
 | ☁️ | **Automatische Backups** | Google Drive, Nextcloud oder lokal — täglich gesichert |
 | 📎 | **Dokumente anhängen** | Regiescheine, Fotos und Lieferscheine direkt zum Eintrag |
+| 📴 | **Offline-fähig** | Funktioniert komplett ohne Internet — Cloud ist optional |
+| 🚫 | **Kein Tracking** | Keine Werbung, kein Analytics, keine Datensammlung |
+| 🌍 | **Bilingual** | Deutsch & Englisch — Sprache in den Einstellungen umschaltbar |
+| 🧭 | **Onboarding & Tour** | Geführter Einstieg + interaktive App-Tour beim ersten Start |
 | 🌙 | **Dark Mode** | Augenschonend, wenn's draußen schon finster ist |
 | 🔧 | **Hausmasta-Modus** | Erweiterte Einstellungen für Profis — bei Bedarf aktivierbar |
 
@@ -155,9 +161,18 @@ Für Profis, die mehr wollen! Aktiviere den **Hausmasta-Modus** in den Einstellu
 - 🖥️ **Nextcloud-Integration** — Backup auf deine eigene Cloud
 - 📦 **JSON Import/Export** — Daten manuell sichern und übertragen
 - 📄 **Automatisches PDF-Archiv** — monatliche PDF-Sicherung auf alle Ziele
+- 🎛️ **PDF-Layout-Toggles** — wähle, welche Felder im PDF erscheinen sollen
 - ⏱️ **Minuten-Modus** — 1-Minuten- statt 15-Minuten-Schritte
 - 🏷️ **Tätigkeitscodes** — Branchen-Presets oder eigene Codes verwalten
+- 🌍 **Locale-Picker** — Bundesland/Kanton für korrekte Feiertage & Berechnung
+- ⏸️ **Auto-Pausen-Regeln** — konfigurierbare Pausenlogik pro Arbeitstyp und Locale
 - 📋 **Nur Aufzeichnung** — Stundenerfassung ohne Soll/Ist-Berechnung
+
+---
+
+## 🌐 Sprachen
+
+Die App-Oberfläche gibt's vollständig auf **Deutsch und Englisch**. Unter **Einstellungen → Sprache** kannst du jederzeit umschalten; beim ersten Start wird die Geräte-Sprache automatisch erkannt.
 
 ---
 
@@ -175,7 +190,10 @@ Für Profis, die mehr wollen! Aktiviere den **Hausmasta-Modus** in den Einstellu
 
 - 🔒 **Lokal first:** Alle Daten bleiben auf deinem Gerät
 - 💾 **Backups:** Optional — lokal, Google Drive oder Nextcloud
+- 🔐 **Sichere Passwörter:** Nextcloud-Credentials liegen im Android Secure Storage, nicht in localStorage
+- 🩹 **Anonymes Crash-Reporting:** Sentry-Reports nur bei echten Abstürzen, deaktivierbar, ohne Eingaben oder Userdaten
 - 🚫 **Kein Tracking:** Keine Werbung, keine Analytics, keine Datensammlung
+- 📖 **Open Source:** Kompletter Code einsehbar, MIT-lizenziert
 - ✅ **Volle Kontrolle:** Du entscheidest, wohin deine Daten gehen
 
 ---
@@ -202,10 +220,14 @@ Wennst magst und dir die App wos wert is, freu i mi über a kloane Anerkennung v
 | | Technologie |
 |---|-------------|
 | 🖥️ Frontend | TypeScript, React, Vite |
-| 📱 Mobile | Capacitor (Android) |
+| 🎨 UI | Tailwind CSS 4, Framer Motion, Lucide Icons |
+| 📱 Mobile | Capacitor (Android), Capacitor Secure Storage |
 | 🗄️ Datenbank | SQLite (Domain-Daten), localStorage nur für UI-/Cache-/Legacy-Migration |
-| 📄 PDF | @react-pdf/renderer (Vektor, durchsuchbar) |
+| 📄 PDF | @react-pdf/renderer (Vektor, durchsuchbar), pdfjs-dist (Vorschau) |
 | ☁️ Cloud | Google Drive API, Nextcloud WebDAV |
+| 🌐 i18n | i18next + react-i18next (Deutsch & Englisch) |
+| 🔍 Validierung | Zod (Backup-Schemas, Import-Validierung) |
+| 🛡️ Monitoring | Sentry (anonymes Crash-Reporting, opt-out) |
 | 🧪 Tests | Vitest |
 
 ---


### PR DESCRIPTION
## Summary

README content audit & refresh to match the 4.3.3 app state. No code/behaviour changes — docs only.

Three packages applied in one commit, mirrored across `README.md` and `README.en.md`.

### 1. Highlights — from 8 to 14 rows

Added features that were already shipping but missing from the list:
- 🎙️ Voice input (speech parser)
- 🇦🇹 Regional holidays (Austria, 16 DE states, 26 CH cantons)
- 📴 Offline-capable
- 🚫 No tracking, no ads
- 🧭 Onboarding + interactive in-app tour
- 🌍 Bilingual (was EN-only — now in both)

### 2. Power-user / Hausmasta mode

Three settings that exist in code but were missing from the list:
- 🎛️ PDF layout toggles (`PdfLayoutSettings.tsx`)
- 🌍 Locale picker (state/canton, drives holidays + calculation)
- ⏸️ Auto-break rules (configurable per work type and locale)

### 3. Tech stack & data security — more transparent

**Tech stack** rows added so the README matches `package.json`:
- 🎨 UI: Tailwind CSS 4, Framer Motion, Lucide
- 📱 Mobile: Capacitor Secure Storage
- 📄 PDF: pdfjs-dist (preview)
- 🔍 Validation: Zod (backup schemas)
- 🛡️ Monitoring: Sentry (opt-out)
- 🌐 i18n line now also in the DE README

**Data security** bullets added:
- 🔐 Nextcloud credentials live in Android Secure Storage
- 🩹 Anonymous crash reporting via Sentry, opt-out
- 📖 Open source / MIT

### 4. Symmetry

The "🌐 Sprachen / Language" section is now in both READMEs at the same position (before Installation). The EN one already existed; DE was missing it.

## Test plan

- [ ] PR preview renders all tables (Highlights, Tech stack) cleanly in both languages
- [ ] DE and EN have the same number of Highlights rows and the same Power-user bullets
- [ ] No broken markdown / table breaks
- [ ] Every new highlight maps to actual code (verified during audit, listed in commit message)

https://claude.ai/code/session_01DreTvRMVVkydbyoVudmhtm

---
_Generated by [Claude Code](https://claude.ai/code/session_01DreTvRMVVkydbyoVudmhtm)_