### PR TITLE
chore: add GitHub-native quality checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+# Keep dependency maintenance inside GitHub instead of an external quality dashboard.
+# Dependabot opens pull requests; CI decides whether updates are safe.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Vienna"
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:15"
+      timezone: "Europe/Vienna"
+    open-pull-requests-limit: 3
+
+  - package-ecosystem: "gradle"
+    directory: "/android"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:30"
+      timezone: "Europe/Vienna"
+    open-pull-requests-limit: 3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,51 @@
+# ============================================================================
+# CodeQL Security Analysis
+# ============================================================================
+#
+# GitHub-native security scanning for the TypeScript/JavaScript app code.
+# Android dependencies are kept fresh by Dependabot; Android CodeQL can be
+# added later if we want a heavier Gradle-based scan.
+#
+# ============================================================================
+
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly scan, Monday 07:00 Europe/Vienna during winter / 08:00 during DST.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze JavaScript/TypeScript
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+          build-mode: none
+          queries: security-extended,security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:javascript-typescript"

--- a/README.en.md
+++ b/README.en.md
@@ -20,8 +20,8 @@
   <a href="https://github.com/D3rPaPaH0d3n/eStundnzettl/actions/workflows/ci.yml">
     <img src="https://img.shields.io/github/actions/workflow/status/D3rPaPaH0d3n/eStundnzettl/ci.yml?branch=main&label=CI&color=2ea44f&style=for-the-badge&logo=githubactions&logoColor=white" alt="CI Status" />
   </a>
-  <a href="https://app.codacy.com/gh/D3rPaPaH0d3n/eStundnzettl/dashboard">
-    <img src="https://img.shields.io/codacy/grade/85110d7924544b05a47c2dc3fada1371?label=Code%20Quality&style=for-the-badge&logo=codacy&logoColor=white" alt="Codacy Code Quality" />
+  <a href="https://github.com/D3rPaPaH0d3n/eStundnzettl/actions/workflows/codeql.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/D3rPaPaH0d3n/eStundnzettl/codeql.yml?branch=main&label=CodeQL&color=2563eb&style=for-the-badge&logo=github&logoColor=white" alt="CodeQL Security Analysis" />
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@
   <a href="https://github.com/D3rPaPaH0d3n/eStundnzettl/actions/workflows/ci.yml">
     <img src="https://img.shields.io/github/actions/workflow/status/D3rPaPaH0d3n/eStundnzettl/ci.yml?branch=main&label=CI&color=2ea44f&style=for-the-badge&logo=githubactions&logoColor=white" alt="CI Status" />
   </a>
-  <a href="https://app.codacy.com/gh/D3rPaPaH0d3n/eStundnzettl/dashboard">
-    <img src="https://img.shields.io/codacy/grade/85110d7924544b05a47c2dc3fada1371?label=Code%20Quality&style=for-the-badge&logo=codacy&logoColor=white" alt="Codacy Code Quality" />
+  <a href="https://github.com/D3rPaPaH0d3n/eStundnzettl/actions/workflows/codeql.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/D3rPaPaH0d3n/eStundnzettl/codeql.yml?branch=main&label=CodeQL&color=2563eb&style=for-the-badge&logo=github&logoColor=white" alt="CodeQL Security Analysis" />
   </a>
 </p>
 


### PR DESCRIPTION
## Summary
- add CodeQL security analysis for JavaScript/TypeScript
- add Dependabot updates for npm, GitHub Actions, and Android Gradle dependencies
- replace the removed Codacy README badge with a GitHub-native CodeQL badge

## Validation
- YAML parsed successfully with PyYAML
- npm run lint -- --max-warnings=0
