### PR TITLE
chore: add SonarQube Cloud analysis

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,53 @@
+# ============================================================================
+# SonarQube Cloud Analysis
+# ============================================================================
+#
+# Code-quality scan for maintainability/reliability/security trends.
+# Coverage is measured first so Sonar can display it, but this workflow does
+# not add a hard local coverage threshold.
+#
+# ============================================================================
+
+name: SonarQube Cloud
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: sonarcloud-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze code quality
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run coverage
+        run: npm run coverage
+
+      - name: SonarQube Cloud Scan
+        uses: SonarSource/sonarqube-scan-action@v8
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/README.en.md
+++ b/README.en.md
@@ -26,6 +26,9 @@
   <a href="https://github.com/D3rPaPaH0d3n/eStundnzettl/actions/workflows/coverage-badge.yml">
     <img src="./badges/coverage.svg" alt="Test Coverage" />
   </a>
+  <a href="https://sonarcloud.io/summary/new_code?id=D3rPaPaH0d3n_eStundnzettl">
+    <img src="https://sonarcloud.io/api/project_badges/measure?project=D3rPaPaH0d3n_eStundnzettl&metric=alert_status" alt="SonarQube Cloud Quality Gate" />
+  </a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@
   <a href="https://github.com/D3rPaPaH0d3n/eStundnzettl/actions/workflows/coverage-badge.yml">
     <img src="./badges/coverage.svg" alt="Test Coverage" />
   </a>
+  <a href="https://sonarcloud.io/summary/new_code?id=D3rPaPaH0d3n_eStundnzettl">
+    <img src="https://sonarcloud.io/api/project_badges/measure?project=D3rPaPaH0d3n_eStundnzettl&metric=alert_status" alt="SonarQube Cloud Quality Gate" />
+  </a>
 </p>
 
 <p align="center">

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,11 @@
+sonar.organization=d3rpapah0d3n
+sonar.projectKey=D3rPaPaH0d3n_eStundnzettl
+sonar.projectName=eStundnzettl
+
+sonar.sources=src
+sonar.tests=src
+sonar.test.inclusions=src/**/__tests__/**/*.test.*,src/**/*.test.*
+sonar.exclusions=src/**/__tests__/**,src/**/*.test.*,src/test/**,src/**/*.d.ts,src/**/*.json,src/**/*.md,src/**/*.css,src/locales/**,src/i18n/locales/**,src/i18n/TRANSLATION_STATUS.md
+
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.sourceEncoding=UTF-8

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -8,7 +8,7 @@ export default defineConfig({
     include: ["src/**/__tests__/**/*.test.{js,jsx,ts,tsx}", "src/**/*.test.{js,jsx,ts,tsx}"],
     coverage: {
       provider: "v8",
-      reporter: ["text", "html", "json-summary"],
+      reporter: ["text", "html", "json-summary", "lcov"],
       include: ["src/**/*.{js,jsx,ts,tsx}"],
       exclude: [
         "**/__tests__/**",


### PR DESCRIPTION
## Summary
- add SonarQube Cloud project configuration
- add a GitHub Actions workflow that runs coverage and submits Sonar analysis
- add lcov coverage output for Sonar
- add Sonar Quality Gate badge to both READMEs

## Sonar
- organization: d3rpapah0d3n
- projectKey: D3rPaPaH0d3n_eStundnzettl

## Validation
- parsed .github/workflows/sonarcloud.yml with PyYAML
- npm run coverage and verified coverage/lcov.info exists
- npm run lint -- --max-warnings=0

No hard local coverage threshold is introduced.
