### PR TITLE
ci: skip Sonar scan for Dependabot PRs

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -24,6 +24,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze code quality
+    if: ${{ github.event_name != 'pull_request' || github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Dependabot pull_request runs cannot access SONAR_TOKEN, so Sonar fails before analyzing code. This keeps Sonar enabled for main/pushes and normal PRs, but skips it for Dependabot PRs to keep dependency updates clean.