### PR TITLE
fix: handle browser close promise in cleanup

### DIFF
--- a/src/components/Settings/BackupSettings.tsx
+++ b/src/components/Settings/BackupSettings.tsx
@@ -276,11 +276,9 @@ const BackupSettings: React.FC<Props> = ({
     }
     
     // Try to close browser (best effort)
-    try {
-      Browser.close();
-    } catch {
+    void Browser.close().catch(() => {
       // Ignore errors - browser might already be closed
-    }
+    });
   };
 
   const handleBrowserFinished = () => {


### PR DESCRIPTION
Fixes the Sonar reliability issue on main by handling the Browser.close() promise in cleanup.\n\nVerification:\n- npm run lint -- --max-warnings=0\n- npm run typecheck\n- npm test -- --run src/components/Settings/__tests__/PlayServicesBanner.test.tsx\n- npm run build