### PR TITLE
chore(android): update Gradle wrapper for AGP 9.2.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:9.0.0'
+        classpath 'com.android.tools.build:gradle:9.2.1'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.21'
         classpath 'org.jetbrains.kotlin:compose-compiler-gradle-plugin:2.3.21'
         classpath 'com.google.gms:google-services:4.4.2'

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- updates Android Gradle Plugin from 9.0.0 to 9.2.1
- updates Gradle wrapper from 9.1.0 to 9.4.1 so AGP 9.2.1 can run
- supersedes Dependabot PR #51, which failed Debug APK verification because the wrapper was still on Gradle 9.1.0

## Verification
- `npm run lint -- --max-warnings=0`
- `npm run typecheck`
- `npm test -- --run src/components/Settings/__tests__/PlayServicesBanner.test.tsx`
- `npm run build`

Next: run `Build Debug APK` on this branch before merging.