### PR TITLE
[codex] Add Gemini Nano diagnostics

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -64,6 +64,8 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:5.3.2'
     implementation 'androidx.activity:activity-compose:1.11.0'
     implementation 'androidx.compose.material3:material3:1.4.0'
+    implementation 'com.google.mlkit:genai-prompt:1.0.0-beta2'
+    implementation 'com.google.mlkit:genai-speech-recognition:1.0.0-alpha1'
 }
 
 apply from: 'capacitor.build.gradle'

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -47,6 +47,7 @@
     </application>
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
 </manifest>

--- a/android/app/src/main/java/com/eStundnzettl/app/MainActivity.java
+++ b/android/app/src/main/java/com/eStundnzettl/app/MainActivity.java
@@ -24,6 +24,7 @@ public class MainActivity extends BridgeActivity implements ModifiedMainActivity
         registerPlugin(Material3DatePickerPlugin.class);
         registerPlugin(DynamicColorsPlugin.class);
         registerPlugin(SystemBarsPlugin.class);
+        registerPlugin(NanoDiagnosticsPlugin.class);
 
         super.onCreate(savedInstanceState);
         // Enable edge-to-edge display for Android 15+ compatibility

--- a/android/app/src/main/java/com/eStundnzettl/app/NanoDiagnosticsPlugin.kt
+++ b/android/app/src/main/java/com/eStundnzettl/app/NanoDiagnosticsPlugin.kt
@@ -1,13 +1,18 @@
 package com.estundnzettl.app
 
+import android.Manifest
 import android.content.pm.PackageManager
 import android.os.Build
 import com.getcapacitor.JSObject
+import com.getcapacitor.PermissionState
 import com.getcapacitor.Plugin
 import com.getcapacitor.PluginCall
 import com.getcapacitor.PluginMethod
 import com.getcapacitor.annotation.CapacitorPlugin
+import com.getcapacitor.annotation.Permission
+import com.getcapacitor.annotation.PermissionCallback
 import com.google.common.util.concurrent.ListenableFuture
+import com.google.mlkit.genai.common.audio.AudioSource
 import com.google.mlkit.genai.common.DownloadCallback
 import com.google.mlkit.genai.common.FeatureStatus
 import com.google.mlkit.genai.common.GenAiException
@@ -18,14 +23,23 @@ import com.google.mlkit.genai.prompt.java.GenerativeModelFutures
 import com.google.mlkit.genai.speechrecognition.SpeechRecognition
 import com.google.mlkit.genai.speechrecognition.SpeechRecognizer
 import com.google.mlkit.genai.speechrecognition.SpeechRecognizerOptions
+import com.google.mlkit.genai.speechrecognition.SpeechRecognizerRequest
+import com.google.mlkit.genai.speechrecognition.SpeechRecognizerResponse
 import java.util.Locale
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 
-@CapacitorPlugin(name = "NanoDiagnostics")
+@CapacitorPlugin(
+    name = "NanoDiagnostics",
+    permissions = [
+        Permission(strings = [Manifest.permission.RECORD_AUDIO], alias = "microphone"),
+    ],
+)
 class NanoDiagnosticsPlugin : Plugin() {
     private val executor = Executors.newSingleThreadExecutor()
 
@@ -131,6 +145,90 @@ class NanoDiagnosticsPlugin : Plugin() {
                 call.resolve(result)
             } catch (e: Exception) {
                 call.reject("Prompt smoke test failed", e)
+            }
+        }
+    }
+
+    @PluginMethod
+    fun recognizeSpeech(call: PluginCall) {
+        if (getPermissionState("microphone") != PermissionState.GRANTED) {
+            requestPermissionForAlias("microphone", call, "recognizeSpeechPermissionCallback")
+            return
+        }
+
+        runSpeechRecognition(call)
+    }
+
+    @PermissionCallback
+    private fun recognizeSpeechPermissionCallback(call: PluginCall) {
+        if (getPermissionState("microphone") != PermissionState.GRANTED) {
+            call.reject("Microphone permission denied")
+            return
+        }
+
+        runSpeechRecognition(call)
+    }
+
+    private fun runSpeechRecognition(call: PluginCall) {
+        executor.execute {
+            var recognizer: SpeechRecognizer? = null
+            try {
+                recognizer = createSpeechRecognizer()
+                val status = runBlocking { recognizer.checkStatus() }
+                if (status != FeatureStatus.AVAILABLE) {
+                    call.reject("Speech Advanced de-DE is not available: ${statusName(status)}")
+                    return@execute
+                }
+
+                val request = SpeechRecognizerRequest.builder().apply {
+                    audioSource = AudioSource.fromMic()
+                }.build()
+                val finalTextParts = mutableListOf<String>()
+                var partialText = ""
+
+                val completed = runBlocking {
+                    withTimeoutOrNull(45_000L) {
+                        recognizer.startRecognition(request).takeWhile { response ->
+                            when (response) {
+                                is SpeechRecognizerResponse.PartialTextResponse -> {
+                                    partialText = response.text
+                                    true
+                                }
+
+                                is SpeechRecognizerResponse.FinalTextResponse -> {
+                                    if (response.text.isNotBlank()) {
+                                        finalTextParts.add(response.text.trim())
+                                    }
+                                    true
+                                }
+
+                                is SpeechRecognizerResponse.ErrorResponse -> {
+                                    throw response.e
+                                }
+
+                                is SpeechRecognizerResponse.CompletedResponse -> false
+                            }
+                        }.collect()
+                        true
+                    }
+                } ?: false
+
+                val text = finalTextParts.joinToString(" ").ifBlank { partialText.trim() }
+                if (text.isBlank()) {
+                    call.reject(if (completed) "No speech recognized" else "Speech recognition timed out")
+                    return@execute
+                }
+
+                val result = JSObject()
+                result.put("text", text)
+                call.resolve(result)
+            } catch (e: Exception) {
+                call.reject("Speech recognition failed", e)
+            } finally {
+                runCatching {
+                    if (recognizer != null) runBlocking { recognizer.stopRecognition() }
+                }
+                runCatching { recognizer?.close() }
             }
         }
     }

--- a/android/app/src/main/java/com/eStundnzettl/app/NanoDiagnosticsPlugin.kt
+++ b/android/app/src/main/java/com/eStundnzettl/app/NanoDiagnosticsPlugin.kt
@@ -1,6 +1,5 @@
 package com.estundnzettl.app
 
-import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
 import com.getcapacitor.JSObject
@@ -12,9 +11,17 @@ import com.google.common.util.concurrent.ListenableFuture
 import com.google.mlkit.genai.common.DownloadCallback
 import com.google.mlkit.genai.common.FeatureStatus
 import com.google.mlkit.genai.common.GenAiException
+import com.google.mlkit.genai.prompt.GenerateContentRequest
+import com.google.mlkit.genai.prompt.Generation
+import com.google.mlkit.genai.prompt.TextPart
+import com.google.mlkit.genai.prompt.java.GenerativeModelFutures
+import com.google.mlkit.genai.speechrecognition.SpeechRecognition
+import com.google.mlkit.genai.speechrecognition.SpeechRecognizer
+import com.google.mlkit.genai.speechrecognition.SpeechRecognizerOptions
 import java.util.Locale
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.runBlocking
 
 @CapacitorPlugin(name = "NanoDiagnostics")
 class NanoDiagnosticsPlugin : Plugin() {
@@ -74,35 +81,17 @@ class NanoDiagnosticsPlugin : Plugin() {
         executor.execute {
             try {
                 val prompt = createPromptClient()
-                val textPart = Class
-                    .forName("com.google.mlkit.genai.prompt.TextPart")
-                    .getConstructor(String::class.java)
-                    .newInstance("Return exactly this text and nothing else: ESTUNDNZETTL_NANO_OK")
-                val contentPartClass = Class.forName("com.google.mlkit.genai.prompt.ContentPart")
-                val builderClass = Class.forName("com.google.mlkit.genai.prompt.GenerateContentRequest\$Builder")
-                val requestBuilder = runCatching {
-                    builderClass.getConstructor(contentPartClass).newInstance(textPart)
-                }.getOrElse {
-                    val partArray = java.lang.reflect.Array.newInstance(contentPartClass, 1)
-                    java.lang.reflect.Array.set(partArray, 0, textPart)
-                    builderClass.getConstructor(partArray.javaClass).newInstance(partArray)
-                }
-                val request = requestBuilder.let { builder ->
-                    runCatching {
-                        builder.javaClass.getMethod("setTemperature", Float::class.javaPrimitiveType).invoke(builder, 0.0f)
-                    }
-                    runCatching {
-                        builder.javaClass.getMethod("setMaxOutputTokens", Int::class.javaPrimitiveType).invoke(builder, 16)
-                    }
-                    builder.javaClass.getMethod("build").invoke(builder)
-                }
-                @Suppress("UNCHECKED_CAST")
-                val future = prompt.javaClass.getMethod("generateContent", request.javaClass).invoke(prompt, request) as ListenableFuture<Any>
+                val request = GenerateContentRequest.Builder(
+                    TextPart("Return exactly this text and nothing else: ESTUNDNZETTL_NANO_OK"),
+                ).apply {
+                    setTemperature(0.0f)
+                    setMaxOutputTokens(16)
+                }.build()
+                val future = prompt.generateContent(request)
                 val response = future.get(30, TimeUnit.SECONDS)
-                val responseText = response.javaClass.methods
-                    .firstOrNull { it.name == "getText" && it.parameterCount == 0 }
-                    ?.invoke(response)
-                    ?.toString()
+                val responseText = response.candidates
+                    .firstOrNull()
+                    ?.text
                     ?: response.toString()
 
                 val result = JSObject()
@@ -115,15 +104,16 @@ class NanoDiagnosticsPlugin : Plugin() {
     }
 
     private fun checkSpeechAdvanced(out: JSObject) {
+        var recognizer: SpeechRecognizer? = null
         try {
-            val recognizer = createSpeechRecognizer()
-            @Suppress("UNCHECKED_CAST")
-            val future = recognizer.javaClass.getMethod("checkStatus").invoke(recognizer) as ListenableFuture<Int>
-            out.put("status", statusName(future.get(15, TimeUnit.SECONDS)))
-            runCatching { recognizer.javaClass.getMethod("close").invoke(recognizer) }
+            recognizer = createSpeechRecognizer()
+            val status = runBlocking { recognizer.checkStatus() }
+            out.put("status", statusName(status))
         } catch (e: Exception) {
             out.put("status", "ERROR")
             out.put("error", e.toString())
+        } finally {
+            runCatching { recognizer?.close() }
         }
     }
 
@@ -139,40 +129,17 @@ class NanoDiagnosticsPlugin : Plugin() {
         }
     }
 
-    private fun createSpeechRecognizer(): Any {
-        val optionsBuilder = Class
-            .forName("com.google.mlkit.genai.speechrecognition.SpeechRecognizerOptions")
-            .getMethod("builder", Context::class.java)
-            .invoke(null, context)!!
+    private fun createSpeechRecognizer(): SpeechRecognizer {
+        val options = SpeechRecognizerOptions.builder().apply {
+            setLocale(Locale.GERMANY)
+            setPreferredMode(SpeechRecognizerOptions.Mode.MODE_ADVANCED)
+        }.build()
 
-        runCatching {
-            optionsBuilder.javaClass.getMethod("setLocale", Locale::class.java).invoke(optionsBuilder, Locale.GERMANY)
-        }
-
-        runCatching {
-            val modeClass = Class.forName("com.google.mlkit.genai.speechrecognition.SpeechRecognizerOptions\$Mode")
-            val advanced = modeClass.enumConstants.first { (it as Enum<*>).name == "MODE_ADVANCED" }
-            optionsBuilder.javaClass.getMethod("setPreferredMode", modeClass).invoke(optionsBuilder, advanced)
-        }
-
-        val options = optionsBuilder.javaClass.getMethod("build").invoke(optionsBuilder)!!
-        return Class
-            .forName("com.google.mlkit.genai.speechrecognition.SpeechRecognition")
-            .getMethod("getClient", options.javaClass)
-            .invoke(null, options)!!
+        return SpeechRecognition.getClient(options)
     }
 
-    private fun createPromptClient(): Any {
-        val generation = Class
-            .forName("com.google.mlkit.genai.prompt.Generation")
-            .getField("INSTANCE")
-            .get(null)
-        val model = generation.javaClass.getMethod("getClient").invoke(generation)
-        return Class
-            .forName("com.google.mlkit.genai.prompt.GenerativeModelFutures")
-            .getMethod("from", Class.forName("com.google.mlkit.genai.prompt.GenerativeModel"))
-            .invoke(null, model)!!
-    }
+    private fun createPromptClient(): GenerativeModelFutures =
+        GenerativeModelFutures.from(Generation.getClient())
 
     private fun statusName(status: Int): String =
         when (status) {

--- a/android/app/src/main/java/com/eStundnzettl/app/NanoDiagnosticsPlugin.kt
+++ b/android/app/src/main/java/com/eStundnzettl/app/NanoDiagnosticsPlugin.kt
@@ -1,8 +1,6 @@
 package com.estundnzettl.app
 
 import android.Manifest
-import android.content.pm.PackageManager
-import android.os.Build
 import com.getcapacitor.JSObject
 import com.getcapacitor.PermissionState
 import com.getcapacitor.Plugin
@@ -47,18 +45,10 @@ class NanoDiagnosticsPlugin : Plugin() {
     fun getStatus(call: PluginCall) {
         executor.execute {
             val result = JSObject()
-            result.put("androidSdk", Build.VERSION.SDK_INT)
-            result.put("device", "${Build.MANUFACTURER} ${Build.MODEL}")
-            result.put("aicoreVersion", getPackageVersion("com.google.android.aicore"))
-            result.put("aicoreInstalled", result.getString("aicoreVersion") != null)
-
             val speech = JSObject()
-            val prompt = JSObject()
             result.put("speechAdvanced", speech)
-            result.put("prompt", prompt)
 
             checkSpeechAdvanced(speech)
-            checkPrompt(prompt)
 
             call.resolve(result)
         }
@@ -280,16 +270,4 @@ class NanoDiagnosticsPlugin : Plugin() {
             else -> "UNKNOWN_$status"
         }
 
-    private fun getPackageVersion(packageName: String): String? =
-        try {
-            val info = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                context.packageManager.getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(0))
-            } else {
-                @Suppress("DEPRECATION")
-                context.packageManager.getPackageInfo(packageName, 0)
-            }
-            info.versionName
-        } catch (_: PackageManager.NameNotFoundException) {
-            null
-        }
 }

--- a/android/app/src/main/java/com/eStundnzettl/app/NanoDiagnosticsPlugin.kt
+++ b/android/app/src/main/java/com/eStundnzettl/app/NanoDiagnosticsPlugin.kt
@@ -1,0 +1,198 @@
+package com.estundnzettl.app
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import com.getcapacitor.JSObject
+import com.getcapacitor.Plugin
+import com.getcapacitor.PluginCall
+import com.getcapacitor.PluginMethod
+import com.getcapacitor.annotation.CapacitorPlugin
+import com.google.common.util.concurrent.ListenableFuture
+import com.google.mlkit.genai.common.DownloadCallback
+import com.google.mlkit.genai.common.FeatureStatus
+import com.google.mlkit.genai.common.GenAiException
+import java.util.Locale
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+@CapacitorPlugin(name = "NanoDiagnostics")
+class NanoDiagnosticsPlugin : Plugin() {
+    private val executor = Executors.newSingleThreadExecutor()
+
+    @PluginMethod
+    fun getStatus(call: PluginCall) {
+        executor.execute {
+            val result = JSObject()
+            result.put("androidSdk", Build.VERSION.SDK_INT)
+            result.put("device", "${Build.MANUFACTURER} ${Build.MODEL}")
+            result.put("aicoreVersion", getPackageVersion("com.google.android.aicore"))
+            result.put("aicoreInstalled", result.getString("aicoreVersion") != null)
+
+            val speech = JSObject()
+            val prompt = JSObject()
+            result.put("speechAdvanced", speech)
+            result.put("prompt", prompt)
+
+            checkSpeechAdvanced(speech)
+            checkPrompt(prompt)
+
+            call.resolve(result)
+        }
+    }
+
+    @PluginMethod
+    fun downloadPrompt(call: PluginCall) {
+        executor.execute {
+            try {
+                val prompt = createPromptClient()
+                prompt.javaClass
+                    .getMethod("download", DownloadCallback::class.java)
+                    .invoke(
+                        prompt,
+                        object : DownloadCallback {
+                            override fun onDownloadStarted(totalBytesToDownload: Long) = Unit
+                            override fun onDownloadProgress(totalBytesDownloaded: Long) = Unit
+
+                            override fun onDownloadCompleted() {
+                                call.resolve()
+                            }
+
+                            override fun onDownloadFailed(e: GenAiException) {
+                                call.reject("Prompt download failed", e)
+                            }
+                        },
+                    )
+            } catch (e: Exception) {
+                call.reject("Prompt download could not be started", e)
+            }
+        }
+    }
+
+    @PluginMethod
+    fun runPromptSmokeTest(call: PluginCall) {
+        executor.execute {
+            try {
+                val prompt = createPromptClient()
+                val textPart = Class
+                    .forName("com.google.mlkit.genai.prompt.TextPart")
+                    .getConstructor(String::class.java)
+                    .newInstance("Return exactly this text and nothing else: ESTUNDNZETTL_NANO_OK")
+                val contentPartClass = Class.forName("com.google.mlkit.genai.prompt.ContentPart")
+                val builderClass = Class.forName("com.google.mlkit.genai.prompt.GenerateContentRequest\$Builder")
+                val requestBuilder = runCatching {
+                    builderClass.getConstructor(contentPartClass).newInstance(textPart)
+                }.getOrElse {
+                    val partArray = java.lang.reflect.Array.newInstance(contentPartClass, 1)
+                    java.lang.reflect.Array.set(partArray, 0, textPart)
+                    builderClass.getConstructor(partArray.javaClass).newInstance(partArray)
+                }
+                val request = requestBuilder.let { builder ->
+                    runCatching {
+                        builder.javaClass.getMethod("setTemperature", Float::class.javaPrimitiveType).invoke(builder, 0.0f)
+                    }
+                    runCatching {
+                        builder.javaClass.getMethod("setMaxOutputTokens", Int::class.javaPrimitiveType).invoke(builder, 16)
+                    }
+                    builder.javaClass.getMethod("build").invoke(builder)
+                }
+                @Suppress("UNCHECKED_CAST")
+                val future = prompt.javaClass.getMethod("generateContent", request.javaClass).invoke(prompt, request) as ListenableFuture<Any>
+                val response = future.get(30, TimeUnit.SECONDS)
+                val responseText = response.javaClass.methods
+                    .firstOrNull { it.name == "getText" && it.parameterCount == 0 }
+                    ?.invoke(response)
+                    ?.toString()
+                    ?: response.toString()
+
+                val result = JSObject()
+                result.put("text", responseText)
+                call.resolve(result)
+            } catch (e: Exception) {
+                call.reject("Prompt smoke test failed", e)
+            }
+        }
+    }
+
+    private fun checkSpeechAdvanced(out: JSObject) {
+        try {
+            val recognizer = createSpeechRecognizer()
+            @Suppress("UNCHECKED_CAST")
+            val future = recognizer.javaClass.getMethod("checkStatus").invoke(recognizer) as ListenableFuture<Int>
+            out.put("status", statusName(future.get(15, TimeUnit.SECONDS)))
+            runCatching { recognizer.javaClass.getMethod("close").invoke(recognizer) }
+        } catch (e: Exception) {
+            out.put("status", "ERROR")
+            out.put("error", e.toString())
+        }
+    }
+
+    private fun checkPrompt(out: JSObject) {
+        try {
+            val prompt = createPromptClient()
+            @Suppress("UNCHECKED_CAST")
+            val future = prompt.javaClass.getMethod("checkStatus").invoke(prompt) as ListenableFuture<Int>
+            out.put("status", statusName(future.get(15, TimeUnit.SECONDS)))
+        } catch (e: Exception) {
+            out.put("status", "ERROR")
+            out.put("error", e.toString())
+        }
+    }
+
+    private fun createSpeechRecognizer(): Any {
+        val optionsBuilder = Class
+            .forName("com.google.mlkit.genai.speechrecognition.SpeechRecognizerOptions")
+            .getMethod("builder", Context::class.java)
+            .invoke(null, context)!!
+
+        runCatching {
+            optionsBuilder.javaClass.getMethod("setLocale", Locale::class.java).invoke(optionsBuilder, Locale.GERMANY)
+        }
+
+        runCatching {
+            val modeClass = Class.forName("com.google.mlkit.genai.speechrecognition.SpeechRecognizerOptions\$Mode")
+            val advanced = modeClass.enumConstants.first { (it as Enum<*>).name == "MODE_ADVANCED" }
+            optionsBuilder.javaClass.getMethod("setPreferredMode", modeClass).invoke(optionsBuilder, advanced)
+        }
+
+        val options = optionsBuilder.javaClass.getMethod("build").invoke(optionsBuilder)!!
+        return Class
+            .forName("com.google.mlkit.genai.speechrecognition.SpeechRecognition")
+            .getMethod("getClient", options.javaClass)
+            .invoke(null, options)!!
+    }
+
+    private fun createPromptClient(): Any {
+        val generation = Class
+            .forName("com.google.mlkit.genai.prompt.Generation")
+            .getField("INSTANCE")
+            .get(null)
+        val model = generation.javaClass.getMethod("getClient").invoke(generation)
+        return Class
+            .forName("com.google.mlkit.genai.prompt.GenerativeModelFutures")
+            .getMethod("from", Class.forName("com.google.mlkit.genai.prompt.GenerativeModel"))
+            .invoke(null, model)!!
+    }
+
+    private fun statusName(status: Int): String =
+        when (status) {
+            FeatureStatus.UNAVAILABLE -> "UNAVAILABLE"
+            FeatureStatus.DOWNLOADABLE -> "DOWNLOADABLE"
+            FeatureStatus.DOWNLOADING -> "DOWNLOADING"
+            FeatureStatus.AVAILABLE -> "AVAILABLE"
+            else -> "UNKNOWN_$status"
+        }
+
+    private fun getPackageVersion(packageName: String): String? =
+        try {
+            val info = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                context.packageManager.getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(0))
+            } else {
+                @Suppress("DEPRECATION")
+                context.packageManager.getPackageInfo(packageName, 0)
+            }
+            info.versionName
+        } catch (_: PackageManager.NameNotFoundException) {
+            null
+        }
+}

--- a/android/app/src/main/java/com/eStundnzettl/app/NanoDiagnosticsPlugin.kt
+++ b/android/app/src/main/java/com/eStundnzettl/app/NanoDiagnosticsPlugin.kt
@@ -31,6 +31,8 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
+import org.json.JSONArray
+import org.json.JSONObject
 
 @CapacitorPlugin(
     name = "NanoDiagnostics",
@@ -135,6 +137,47 @@ class NanoDiagnosticsPlugin : Plugin() {
                 call.resolve(result)
             } catch (e: Exception) {
                 call.reject("Prompt smoke test failed", e)
+            }
+        }
+    }
+
+    @PluginMethod
+    fun parseEntrySpeech(call: PluginCall) {
+        executor.execute {
+            try {
+                val text = call.getString("text")?.trim().orEmpty()
+                val date = call.getString("date")?.trim().orEmpty()
+                if (text.isBlank()) {
+                    call.reject("Speech text is required")
+                    return@execute
+                }
+                if (!Regex("""\d{4}-\d{2}-\d{2}""").matches(date)) {
+                    call.reject("Current date is required")
+                    return@execute
+                }
+
+                val workCodes = call.getArray("workCodes") ?: JSONArray()
+                val existingProjects = call.getArray("existingProjects") ?: JSONArray()
+                val prompt = createPromptClient()
+                val request = GenerateContentRequest.Builder(
+                    TextPart(buildEntryParsePrompt(text, date, workCodes, existingProjects)),
+                ).apply {
+                    temperature = 0.0f
+                    maxOutputTokens = 512
+                }.build()
+
+                val response = prompt.generateContent(request).get(30, TimeUnit.SECONDS)
+                val responseText = response.candidates
+                    .firstOrNull()
+                    ?.text
+                    ?: response.toString()
+                val parsed = JSONObject(extractJsonObject(responseText))
+                val result = JSObject()
+                copyKnownEntryFields(parsed, result)
+                result.put("rawText", text)
+                call.resolve(result)
+            } catch (e: Exception) {
+                call.reject("Entry speech parse failed", e)
             }
         }
     }
@@ -260,6 +303,112 @@ class NanoDiagnosticsPlugin : Plugin() {
 
     private fun createPromptClient(): GenerativeModelFutures =
         GenerativeModelFutures.from(Generation.getClient())
+
+    private fun buildEntryParsePrompt(
+        text: String,
+        date: String,
+        workCodes: JSONArray,
+        existingProjects: JSONArray,
+    ): String {
+        val quotedSpeechText = JSONObject.quote(text)
+        val codeLines = (0 until workCodes.length()).joinToString("\n") { index ->
+            val code = workCodes.optJSONObject(index)
+            "- ${code?.optInt("id")}: ${code?.optString("label")}"
+        }
+        val projectLines = (0 until existingProjects.length()).joinToString("\n") { index ->
+            "- ${existingProjects.optString(index)}"
+        }
+
+        return """
+            Du extrahierst aus einem deutschen Spracheingabe-Text einen eStundnzettl-Eintragsvorschlag.
+            Antworte ausschliesslich als JSON-Objekt ohne Markdown.
+
+            Aktuelles Datum: $date
+
+            Erlaubte Typen:
+            - work: normale Arbeit
+            - drive: Fahrtzeit oder Strecke
+            - vacation: Urlaub
+            - sick: Krankenstand
+            - time_comp: Zeitausgleich
+
+            Erlaubte Taetigkeitscodes:
+            $codeLines
+
+            Bekannte Projekte:
+            $projectLines
+
+            JSON-Schema:
+            {
+              "type": "work|drive|vacation|sick|time_comp",
+              "date": "YYYY-MM-DD",
+              "start": "HH:MM oder null",
+              "end": "HH:MM oder null",
+              "pause": 0,
+              "project": "Projekt/Strecke/Notiz oder null",
+              "codeId": 1,
+              "specialManualMode": false,
+              "confidence": "high|medium|low"
+            }
+
+            Regeln:
+            - Verwende $date, wenn kein anderes Datum genannt wird.
+            - Normalisiere Uhrzeiten auf 24h HH:MM.
+            - "halb fuenf" bedeutet 16:30, wenn es in einem Arbeitstag-Kontext steht.
+            - Pausen immer in Minuten.
+            - Fuer vacation/sick/time_comp ohne Uhrzeiten start/end null und specialManualMode false.
+            - Wenn fuer vacation/sick/time_comp Uhrzeiten genannt werden, specialManualMode true.
+            - Waehle codeId nur aus der erlaubten Liste. Wenn unklar, nimm null.
+            - Bei drive setze pause 0 und codeId 19, wenn vorhanden.
+            - Erfinde keine Zeiten, Projekte oder Codes.
+
+            Spracheingabe als JSON-String:
+            $quotedSpeechText
+        """.trimIndent()
+    }
+
+    private fun extractJsonObject(text: String): String {
+        val start = text.indexOf('{')
+        val end = text.lastIndexOf('}')
+        if (start < 0 || end <= start) {
+            throw IllegalArgumentException("No JSON object in model response")
+        }
+        return text.substring(start, end + 1)
+    }
+
+    private fun copyKnownEntryFields(source: JSONObject, target: JSObject) {
+        val allowedTypes = setOf("work", "drive", "vacation", "sick", "time_comp")
+        val type = source.optString("type")
+        if (type in allowedTypes) target.put("type", type)
+
+        val date = source.optString("date")
+        if (Regex("""\d{4}-\d{2}-\d{2}""").matches(date)) target.put("date", date)
+
+        putNullableString(source, target, "start")
+        putNullableString(source, target, "end")
+        putNullableString(source, target, "project")
+
+        if (source.has("pause") && !source.isNull("pause")) {
+            target.put("pause", source.optInt("pause"))
+        }
+        if (source.has("codeId") && !source.isNull("codeId")) {
+            target.put("codeId", source.optInt("codeId"))
+        }
+        if (source.has("specialManualMode") && !source.isNull("specialManualMode")) {
+            target.put("specialManualMode", source.optBoolean("specialManualMode"))
+        }
+
+        val confidence = source.optString("confidence")
+        if (confidence in setOf("high", "medium", "low")) {
+            target.put("confidence", confidence)
+        }
+    }
+
+    private fun putNullableString(source: JSONObject, target: JSObject, key: String) {
+        if (!source.has(key) || source.isNull(key)) return
+        val value = source.optString(key).trim()
+        if (value.isNotBlank()) target.put(key, value)
+    }
 
     private fun statusName(status: Int): String =
         when (status) {

--- a/android/app/src/main/java/com/eStundnzettl/app/NanoDiagnosticsPlugin.kt
+++ b/android/app/src/main/java/com/eStundnzettl/app/NanoDiagnosticsPlugin.kt
@@ -21,6 +21,8 @@ import com.google.mlkit.genai.speechrecognition.SpeechRecognizerOptions
 import java.util.Locale
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.runBlocking
 
 @CapacitorPlugin(name = "NanoDiagnostics")
@@ -45,6 +47,36 @@ class NanoDiagnosticsPlugin : Plugin() {
             checkPrompt(prompt)
 
             call.resolve(result)
+        }
+    }
+
+    @PluginMethod
+    fun downloadSpeechAdvanced(call: PluginCall) {
+        executor.execute {
+            var speechRecognizer: SpeechRecognizer? = null
+            try {
+                speechRecognizer = createSpeechRecognizer()
+                @Suppress("UNCHECKED_CAST")
+                val downloadFlow = speechRecognizer.javaClass
+                    .getMethod("download")
+                    .invoke(speechRecognizer) as Flow<Any>
+
+                runBlocking {
+                    downloadFlow.collect { status ->
+                        if (status.javaClass.simpleName == "DownloadFailed") {
+                            val error = runCatching {
+                                status.javaClass.getMethod("getE").invoke(status) as? Throwable
+                            }.getOrNull()
+                            throw error ?: IllegalStateException(status.toString())
+                        }
+                    }
+                }
+                call.resolve()
+            } catch (e: Exception) {
+                call.reject("Speech Advanced download could not be started", e)
+            } finally {
+                runCatching { speechRecognizer?.close() }
+            }
         }
     }
 

--- a/android/app/src/main/java/com/eStundnzettl/app/NanoDiagnosticsPlugin.kt
+++ b/android/app/src/main/java/com/eStundnzettl/app/NanoDiagnosticsPlugin.kt
@@ -84,8 +84,8 @@ class NanoDiagnosticsPlugin : Plugin() {
                 val request = GenerateContentRequest.Builder(
                     TextPart("Return exactly this text and nothing else: ESTUNDNZETTL_NANO_OK"),
                 ).apply {
-                    setTemperature(0.0f)
-                    setMaxOutputTokens(16)
+                    temperature = 0.0f
+                    maxOutputTokens = 16
                 }.build()
                 val future = prompt.generateContent(request)
                 val response = future.get(30, TimeUnit.SECONDS)
@@ -131,8 +131,8 @@ class NanoDiagnosticsPlugin : Plugin() {
 
     private fun createSpeechRecognizer(): SpeechRecognizer {
         val options = SpeechRecognizerOptions.builder().apply {
-            setLocale(Locale.GERMANY)
-            setPreferredMode(SpeechRecognizerOptions.Mode.MODE_ADVANCED)
+            locale = Locale.GERMANY
+            preferredMode = SpeechRecognizerOptions.Mode.MODE_ADVANCED
         }.build()
 
         return SpeechRecognition.getClient(options)

--- a/src/components/EntryForm.tsx
+++ b/src/components/EntryForm.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useState, useEffect, useCallback } from "react";
+import React, { forwardRef, useState, useEffect, useCallback, useRef } from "react";
 import type { SyntheticEvent } from "react";
 import { ChevronLeft, ChevronRight, Save, Info, Calendar as CalIcon, Clock, List, Wand2, History, Hourglass, Plus, ChevronDown, Mic, Loader2 } from "lucide-react";
 import { Card, toLocalDateString } from "../utils";
@@ -19,7 +19,7 @@ import { NanoDiagnostics } from "../plugins/NanoDiagnosticsPlugin";
 import { getNativePickerThemeMode } from "../utils/nativePickerTheme";
 import { logger } from "../utils/logger";
 
-import type { Entry, UserData, WorkCode } from "../types";
+import type { Entry, EntryType, UserData, WorkCode } from "../types";
 import type { Locale } from "../locales/types";
 import type { CalculationConfig } from "../types";
 
@@ -42,6 +42,23 @@ const CustomInput = forwardRef<HTMLButtonElement, CustomInputProps>(({ value, on
   </button>
 ));
 CustomInput.displayName = "CustomInput";
+
+const validEntryTypes = new Set(["work", "drive", "vacation", "sick", "time_comp"]);
+const timePattern = /^([01]\d|2[0-3]):[0-5]\d$/;
+const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+type VoiceEntryType = EntryType | "drive";
+
+const isVoiceEntryType = (value: unknown): value is VoiceEntryType =>
+  typeof value === "string" && validEntryTypes.has(value);
+
+const isTimeValue = (value: unknown): value is string =>
+  typeof value === "string" && timePattern.test(value);
+
+const isDateValue = (value: unknown): value is string =>
+  typeof value === "string" && datePattern.test(value);
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value);
 
 interface Props {
   onCancel: () => void;
@@ -120,6 +137,8 @@ const EntryForm: React.FC<Props> = ({
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [showDateFallback, setShowDateFallback] = useState(false);
   const [isRecognizingProject, setIsRecognizingProject] = useState(false);
+  const [isRecognizingEntry, setIsRecognizingEntry] = useState(false);
+  const skipNextAutoTimeRef = useRef(false);
   const isNativePlatform = Capacitor.isNativePlatform();
 
   const date = new Date(`${formDate}T00:00:00`);
@@ -223,6 +242,10 @@ const EntryForm: React.FC<Props> = ({
   useEffect(() => {
     if (isEditing || isLiveEntry) return; 
     if (entryType !== 'work' && entryType !== 'drive') return;
+    if (skipNextAutoTimeRef.current) {
+      skipNextAutoTimeRef.current = false;
+      return;
+    }
     
     const dayEntries = allEntries.filter(e => e.date === formDate && e.type === 'work' && e.end);
     
@@ -312,6 +335,71 @@ const EntryForm: React.FC<Props> = ({
     }
   };
 
+  const handleEntrySpeechInput = async () => {
+    if (!isNativePlatform) {
+      toast.error(t("entryForm.speech.nativeOnly"));
+      return;
+    }
+
+    setIsRecognizingEntry(true);
+    const toastId = toast.loading(t("entryForm.speech.listening"));
+    try {
+      const speech = await NanoDiagnostics.recognizeSpeech();
+      const spokenText = speech.text.trim();
+      if (!spokenText) {
+        toast.error(t("entryForm.speech.empty"));
+        return;
+      }
+
+      const parsed = await NanoDiagnostics.parseEntrySpeech({
+        text: spokenText,
+        date: formDate,
+        workCodes,
+        existingProjects,
+      });
+      const hasParsedTime = isTimeValue(parsed.start) || isTimeValue(parsed.end);
+      if (hasParsedTime) skipNextAutoTimeRef.current = true;
+
+      if (isVoiceEntryType(parsed.type)) {
+        if (parsed.type === "drive") {
+          setEntryType("drive");
+          setCode(WORK_CODE.DRIVE);
+          setPauseDuration(0);
+        } else {
+          setEntryType(parsed.type);
+          if (parsed.type === "work") {
+            const parsedCode = parsed.codeId;
+            const parsedCodeExists = isFiniteNumber(parsedCode)
+              && workCodes.some((workCode) => workCode.id === parsedCode);
+            setCode(parsedCodeExists ? parsedCode : defaultCode);
+          }
+          if (parsed.type === "vacation" || parsed.type === "sick" || parsed.type === "time_comp") {
+            setSpecialManualMode(Boolean(parsed.specialManualMode || hasParsedTime));
+          }
+        }
+      }
+
+      if (isDateValue(parsed.date)) setFormDate(parsed.date);
+      if (isTimeValue(parsed.start)) setStartTime(parsed.start);
+      if (isTimeValue(parsed.end)) setEndTime(parsed.end);
+      if (parsed.type !== "drive" && isFiniteNumber(parsed.pause)) {
+        setPauseDuration(Math.max(0, Math.round(parsed.pause)));
+      }
+      if (typeof parsed.project === "string") {
+        applyProjectText(parsed.project.trim());
+      }
+
+      toast.success(t("entryForm.speech.entryInserted"));
+      Haptics.impact({ style: ImpactStyle.Light }).catch(() => {});
+    } catch (err) {
+      logger.error("[EntryForm] Spracheintrag fehlgeschlagen:", err);
+      toast.error(t("entryForm.speech.entryFailed"));
+    } finally {
+      toast.dismiss(toastId);
+      setIsRecognizingEntry(false);
+    }
+  };
+
   const selectSuggestion = (suggestion: string) => {
     setProject(suggestion);
     setShowSuggestions(false);
@@ -364,20 +452,34 @@ const EntryForm: React.FC<Props> = ({
           <div className="flex justify-between items-center mb-1">
              <div className="text-xs font-bold text-zinc-400 uppercase tracking-wider">{t("entryForm.entryTypeLabel")}</div>
              
-             {entryType === 'work' && code !== WORK_CODE.ARRIVAL && lastWorkEntry && (
+             <div className="flex items-center gap-2">
                <motion.button
                  type="button"
                  whileTap={{ scale: 0.9 }}
-                 onClick={() => {
-                   handleCopyLastEntry();
-                   Haptics.impact({ style: ImpactStyle.Light }).catch(() => {});
-                 }}
-                 className="flex items-center gap-1 text-xs font-bold text-emerald-600 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/20 px-2 py-1 rounded-md border border-emerald-100 dark:border-emerald-800/50"
+                 onClick={handleEntrySpeechInput}
+                 disabled={isRecognizingEntry}
+                 className="flex items-center gap-1 rounded-md border border-zinc-200 bg-white px-2 py-1 text-xs font-bold text-zinc-600 transition-colors hover:border-emerald-200 hover:bg-emerald-50 hover:text-emerald-700 disabled:cursor-not-allowed disabled:opacity-60 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:border-emerald-800 dark:hover:bg-emerald-900/20 dark:hover:text-emerald-300"
+                 aria-label={t("entryForm.speech.entryButton")}
                >
-                 <Wand2 size={12} />
-                 <span>{t("entryForm.asLast")}</span>
+                 {isRecognizingEntry ? <Loader2 size={12} className="animate-spin" /> : <Mic size={12} />}
+                 <span>{t("entryForm.speech.entryButtonShort")}</span>
                </motion.button>
-             )}
+
+               {entryType === 'work' && code !== WORK_CODE.ARRIVAL && lastWorkEntry && (
+                 <motion.button
+                   type="button"
+                   whileTap={{ scale: 0.9 }}
+                   onClick={() => {
+                     handleCopyLastEntry();
+                     Haptics.impact({ style: ImpactStyle.Light }).catch(() => {});
+                   }}
+                   className="flex items-center gap-1 text-xs font-bold text-emerald-600 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/20 px-2 py-1 rounded-md border border-emerald-100 dark:border-emerald-800/50"
+                 >
+                   <Wand2 size={12} />
+                   <span>{t("entryForm.asLast")}</span>
+                 </motion.button>
+               )}
+             </div>
           </div>
 
           <div className="bg-zinc-100 dark:bg-zinc-700 p-1 rounded-xl grid grid-cols-5 gap-1">

--- a/src/components/EntryForm.tsx
+++ b/src/components/EntryForm.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, useState, useEffect, useCallback } from "react";
 import type { SyntheticEvent } from "react";
-import { ChevronLeft, ChevronRight, Save, Info, Calendar as CalIcon, Clock, List, Wand2, History, Hourglass, Plus, ChevronDown } from "lucide-react";
+import { ChevronLeft, ChevronRight, Save, Info, Calendar as CalIcon, Clock, List, Wand2, History, Hourglass, Plus, ChevronDown, Mic, Loader2 } from "lucide-react";
 import { Card, toLocalDateString } from "../utils";
 import { WORK_CODE } from "../hooks/constants";
 import { motion, AnimatePresence } from "framer-motion";
@@ -15,7 +15,9 @@ import SelectionDrawer from "./SelectionDrawer";
 import { Capacitor } from "@capacitor/core";
 import { Material3DatePicker } from "../plugins/Material3DatePickerPlugin";
 import { Material3TimePicker } from "../plugins/Material3TimePickerPlugin";
+import { NanoDiagnostics } from "../plugins/NanoDiagnosticsPlugin";
 import { getNativePickerThemeMode } from "../utils/nativePickerTheme";
+import { logger } from "../utils/logger";
 
 import type { Entry, UserData, WorkCode } from "../types";
 import type { Locale } from "../locales/types";
@@ -117,6 +119,7 @@ const EntryForm: React.FC<Props> = ({
   const [suggestions, setSuggestions] = useState<string[]>([]);
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [showDateFallback, setShowDateFallback] = useState(false);
+  const [isRecognizingProject, setIsRecognizingProject] = useState(false);
   const isNativePlatform = Capacitor.isNativePlatform();
 
   const date = new Date(`${formDate}T00:00:00`);
@@ -267,6 +270,45 @@ const EntryForm: React.FC<Props> = ({
       setShowSuggestions(filtered.length > 0);
     } else {
       setShowSuggestions(false);
+    }
+  };
+
+  const applyProjectText = (value: string) => {
+    setProject(value);
+    const filtered = value
+      ? existingProjects.filter(p =>
+          p.toLowerCase().includes(value.toLowerCase()) && p !== value
+        ).slice(0, 4)
+      : [];
+    setSuggestions(filtered);
+    setShowSuggestions(filtered.length > 0);
+  };
+
+  const handleProjectSpeechInput = async () => {
+    if (!isNativePlatform) {
+      toast.error(t("entryForm.speech.nativeOnly"));
+      return;
+    }
+
+    setIsRecognizingProject(true);
+    const toastId = toast.loading(t("entryForm.speech.listening"));
+    try {
+      const result = await NanoDiagnostics.recognizeSpeech();
+      const spokenText = result.text.trim();
+      if (!spokenText) {
+        toast.error(t("entryForm.speech.empty"));
+        return;
+      }
+      const nextProject = project.trim() ? `${project.trim()} ${spokenText}` : spokenText;
+      applyProjectText(nextProject);
+      toast.success(t("entryForm.speech.inserted"));
+      Haptics.impact({ style: ImpactStyle.Light }).catch(() => {});
+    } catch (err) {
+      logger.error("[EntryForm] Spracheingabe fehlgeschlagen:", err);
+      toast.error(t("entryForm.speech.failed"));
+    } finally {
+      toast.dismiss(toastId);
+      setIsRecognizingProject(false);
     }
   };
 
@@ -558,9 +600,20 @@ const EntryForm: React.FC<Props> = ({
                     onChange={handleProjectChange}
                     onFocus={() => { if(project) handleProjectChange({target: {value: project}} as React.ChangeEvent<HTMLInputElement>) }}
                     onBlur={() => setTimeout(() => setShowSuggestions(false), 200)}
-                    className="w-full p-3 bg-white dark:bg-zinc-700 border border-zinc-300 dark:border-zinc-600 rounded-lg outline-none dark:text-white focus:border-emerald-500 transition-colors"
+                    className="w-full rounded-lg border border-zinc-300 bg-white p-3 pr-12 outline-none transition-colors focus:border-emerald-500 dark:border-zinc-600 dark:bg-zinc-700 dark:text-white"
                     placeholder={t("entryForm.projectPlaceholder")}
                   />
+                  <button
+                    type="button"
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={handleProjectSpeechInput}
+                    disabled={isRecognizingProject}
+                    className="absolute right-2 top-7 flex h-9 w-9 items-center justify-center rounded-lg text-zinc-500 transition-colors hover:bg-emerald-50 hover:text-emerald-600 disabled:opacity-60 dark:text-zinc-300 dark:hover:bg-emerald-900/30 dark:hover:text-emerald-300"
+                    aria-label={t("entryForm.speech.projectButton")}
+                    title={t("entryForm.speech.projectButton")}
+                  >
+                    {isRecognizingProject ? <Loader2 size={18} className="animate-spin" /> : <Mic size={18} />}
+                  </button>
 
                   <AnimatePresence>
                     {showSuggestions && (

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -13,6 +13,7 @@ import CollapsibleCard from "./Settings/CollapsibleCard";
 import BackupSettings from "./Settings/BackupSettings";
 import PdfArchiveSettings from "./Settings/PdfArchiveSettings";
 import AppInfoSettings from "./Settings/AppInfoSettings";
+import NanoDiagnosticsSettings from "./Settings/NanoDiagnosticsSettings";
 import SettingsTourPopup from "./SettingsTourPopup";
 import { analyzeBackupData, applyBackup, readJsonFile } from "../utils/storageBackup";
 import toast from "react-hot-toast";
@@ -422,6 +423,8 @@ const Settings: React.FC<Props> = ({
         locale={locale}
         calculationConfig={calculationConfig}
       />
+
+      {(userData?.expertMode ?? false) && <NanoDiagnosticsSettings />}
 
       {/* 9. App Info & Danger Zone */}
       <div data-settings-tour="help" className="space-y-6">

--- a/src/components/Settings/NanoDiagnosticsSettings.tsx
+++ b/src/components/Settings/NanoDiagnosticsSettings.tsx
@@ -1,73 +1,45 @@
-import React, { useState } from "react";
-import { BrainCircuit, Download, Play, RefreshCw } from "lucide-react";
+import React, { useEffect, useState } from "react";
+import { Download, Mic, RefreshCw } from "lucide-react";
 import { Capacitor } from "@capacitor/core";
 import toast from "react-hot-toast";
 import { Card } from "../../utils";
 import {
   NanoDiagnostics,
   type NanoDiagnosticsResult,
-  type NanoFeatureDiagnostic,
 } from "../../plugins/NanoDiagnosticsPlugin";
 import { logger } from "../../utils/logger";
 
-const statusClasses: Record<string, string> = {
-  AVAILABLE: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300",
-  DOWNLOADABLE: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
-  DOWNLOADING: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
-  UNAVAILABLE: "bg-zinc-100 text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300",
-  ERROR: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300",
+const speechStatusLabel: Record<string, string> = {
+  AVAILABLE: "bereit",
+  DOWNLOADABLE: "nicht bereit",
+  DOWNLOADING: "lädt",
+  UNAVAILABLE: "nicht verfügbar",
+  ERROR: "nicht verfügbar",
 };
 
-const StatusBadge = ({ feature }: { feature?: NanoFeatureDiagnostic }) => {
-  const status = feature?.status ?? "UNKNOWN";
-  const classes = statusClasses[status] ?? "bg-zinc-100 text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300";
-
-  return (
-    <span className={`rounded-full px-2.5 py-1 text-xs font-bold ${classes}`}>
-      {status}
-    </span>
-  );
+const getSpeechStatusClasses = (status?: string) => {
+  if (status === "AVAILABLE") {
+    return "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300";
+  }
+  if (status === "DOWNLOADABLE" || status === "DOWNLOADING") {
+    return "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300";
+  }
+  return "bg-zinc-100 text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300";
 };
-
-const FeatureRow = ({
-  label,
-  feature,
-}: {
-  label: string;
-  feature?: NanoFeatureDiagnostic;
-}) => (
-  <div className="rounded-lg border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-900/40 p-3">
-    <div className="flex items-center justify-between gap-3">
-      <span className="text-sm font-semibold text-zinc-700 dark:text-zinc-200">
-        {label}
-      </span>
-      <StatusBadge feature={feature} />
-    </div>
-    {feature?.error && (
-      <p className="mt-2 break-words text-xs leading-relaxed text-red-600 dark:text-red-300">
-        {feature.error}
-      </p>
-    )}
-  </div>
-);
 
 const NanoDiagnosticsSettings: React.FC = () => {
   const [status, setStatus] = useState<NanoDiagnosticsResult | null>(null);
-  const [smokeResult, setSmokeResult] = useState<string | null>(null);
   const [isBusy, setIsBusy] = useState(false);
   const speechStatus = status?.speechAdvanced.status;
-  const promptStatus = status?.prompt.status;
-  const speechDownloadLabel = speechStatus === "AVAILABLE" ? "Speech bereit" : "Speech laden";
-  const promptDownloadLabel = promptStatus === "AVAILABLE" ? "Prompt bereit" : "Prompt laden";
+  const statusLabel = speechStatus ? speechStatusLabel[speechStatus] ?? "unbekannt" : "ungeprüft";
 
   const loadStatus = async () => {
     if (!Capacitor.isNativePlatform()) {
-      toast("Nano Diagnose ist nur in der Android-App verfügbar.");
+      setStatus({ speechAdvanced: { status: "UNAVAILABLE" } });
       return;
     }
 
     setIsBusy(true);
-    setSmokeResult(null);
     try {
       const next = await NanoDiagnostics.getStatus();
       setStatus(next);
@@ -79,23 +51,8 @@ const NanoDiagnosticsSettings: React.FC = () => {
     }
   };
 
-  const downloadPrompt = async () => {
-    setIsBusy(true);
-    try {
-      await NanoDiagnostics.downloadPrompt();
-      toast.success("Prompt-Modell bereit.");
-      await loadStatus();
-    } catch (err) {
-      logger.error("[NanoDiagnosticsSettings] Prompt-Download fehlgeschlagen:", err);
-      toast.error("Prompt-Download fehlgeschlagen.");
-    } finally {
-      setIsBusy(false);
-    }
-  };
-
   const downloadSpeechAdvanced = async () => {
     setIsBusy(true);
-    setSmokeResult(null);
     try {
       await NanoDiagnostics.downloadSpeechAdvanced();
       toast.success("Speech de-DE bereit.");
@@ -108,95 +65,52 @@ const NanoDiagnosticsSettings: React.FC = () => {
     }
   };
 
-  const runSmokeTest = async () => {
-    setIsBusy(true);
-    setSmokeResult(null);
-    try {
-      const result = await NanoDiagnostics.runPromptSmokeTest();
-      setSmokeResult(result.text);
-    } catch (err) {
-      logger.error("[NanoDiagnosticsSettings] Prompt-Test fehlgeschlagen:", err);
-      toast.error("Prompt-Test fehlgeschlagen.");
-    } finally {
-      setIsBusy(false);
-    }
-  };
+  useEffect(() => {
+    void loadStatus();
+  }, []);
 
   return (
-    <Card className="p-5 space-y-4 border-violet-200 dark:border-violet-900 bg-violet-50/60 dark:bg-violet-950/20">
-      <div className="flex items-start gap-3">
-        <div className="rounded-lg bg-violet-100 p-2 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300">
-          <BrainCircuit size={20} />
+    <Card className="p-4">
+      <div className="flex items-center gap-3">
+        <div className="rounded-lg bg-zinc-100 p-2 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
+          <Mic size={18} />
         </div>
-        <div className="min-w-0 flex-1">
-          <h3 className="font-bold text-zinc-800 dark:text-white">Gemini Nano Diagnose</h3>
-          <p className="mt-1 text-sm leading-relaxed text-zinc-600 dark:text-zinc-300">
-            Prüft AICore, Speech Advanced und Prompt API direkt auf diesem Android-Gerät.
-          </p>
+        <div className="min-w-0 flex-1 text-sm">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-bold text-zinc-800 dark:text-white">Speech Nano</span>
+            <span className={`rounded-full px-2 py-0.5 text-xs font-bold ${getSpeechStatusClasses(speechStatus)}`}>
+              {statusLabel}
+            </span>
+          </div>
+          {status?.speechAdvanced.error && (
+            <p className="mt-1 break-words text-xs text-zinc-500 dark:text-zinc-400">
+              {status.speechAdvanced.error}
+            </p>
+          )}
         </div>
-      </div>
-
-      <div className="grid gap-2">
         <button
           type="button"
           onClick={loadStatus}
           disabled={isBusy}
-          className="flex w-full items-center justify-center gap-2 rounded-xl bg-violet-600 px-4 py-3 text-sm font-bold text-white transition-colors hover:bg-violet-700 disabled:cursor-not-allowed disabled:opacity-60"
+          className="flex h-9 w-9 items-center justify-center rounded-lg text-zinc-500 transition-colors hover:bg-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 dark:text-zinc-300 dark:hover:bg-zinc-800"
+          aria-label="Speech Nano Status prüfen"
+          title="Speech Nano Status prüfen"
         >
-          <RefreshCw size={17} className={isBusy ? "animate-spin" : ""} />
-          Status prüfen
+          <RefreshCw size={16} className={isBusy ? "animate-spin" : ""} />
         </button>
 
-        <div className="grid grid-cols-2 gap-2">
+        {speechStatus === "DOWNLOADABLE" && (
           <button
             type="button"
             onClick={downloadSpeechAdvanced}
-            disabled={isBusy || speechStatus !== "DOWNLOADABLE"}
-            className="flex items-center justify-center gap-2 rounded-xl border border-violet-200 bg-white px-3 py-2.5 text-xs font-bold text-violet-700 transition-colors hover:bg-violet-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-violet-900 dark:bg-zinc-800 dark:text-violet-300 dark:hover:bg-zinc-700"
+            disabled={isBusy}
+            className="flex items-center justify-center gap-1.5 rounded-lg border border-zinc-200 bg-white px-3 py-2 text-xs font-bold text-zinc-700 transition-colors hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200 dark:hover:bg-zinc-700"
           >
-            <Download size={15} />
-            {speechDownloadLabel}
+            <Download size={14} />
+            Laden
           </button>
-
-          <button
-            type="button"
-            onClick={downloadPrompt}
-            disabled={isBusy || promptStatus !== "DOWNLOADABLE"}
-            className="flex items-center justify-center gap-2 rounded-xl border border-violet-200 bg-white px-3 py-2.5 text-xs font-bold text-violet-700 transition-colors hover:bg-violet-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-violet-900 dark:bg-zinc-800 dark:text-violet-300 dark:hover:bg-zinc-700"
-          >
-            <Download size={15} />
-            {promptDownloadLabel}
-          </button>
-
-          <button
-            type="button"
-            onClick={runSmokeTest}
-            disabled={isBusy || promptStatus !== "AVAILABLE"}
-            className="col-span-2 flex items-center justify-center gap-2 rounded-xl border border-violet-200 bg-white px-3 py-2.5 text-xs font-bold text-violet-700 transition-colors hover:bg-violet-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-violet-900 dark:bg-zinc-800 dark:text-violet-300 dark:hover:bg-zinc-700"
-          >
-            <Play size={15} />
-            Prompt testen
-          </button>
-        </div>
+        )}
       </div>
-
-      {status && (
-        <div className="space-y-2">
-          <div className="rounded-lg bg-white/80 p-3 text-xs text-zinc-600 dark:bg-zinc-900/40 dark:text-zinc-300">
-            <div><b>Gerät:</b> {status.device ?? "unbekannt"}</div>
-            <div><b>Android SDK:</b> {status.androidSdk ?? "unbekannt"}</div>
-            <div><b>AICore:</b> {status.aicoreVersion ?? "nicht gefunden"}</div>
-          </div>
-          <FeatureRow label="Speech Advanced de-DE" feature={status.speechAdvanced} />
-          <FeatureRow label="Prompt API" feature={status.prompt} />
-        </div>
-      )}
-
-      {smokeResult && (
-        <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-sm font-semibold text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950/30 dark:text-emerald-300">
-          {smokeResult}
-        </div>
-      )}
     </Card>
   );
 };

--- a/src/components/Settings/NanoDiagnosticsSettings.tsx
+++ b/src/components/Settings/NanoDiagnosticsSettings.tsx
@@ -1,0 +1,175 @@
+import React, { useState } from "react";
+import { BrainCircuit, Download, Play, RefreshCw } from "lucide-react";
+import { Capacitor } from "@capacitor/core";
+import toast from "react-hot-toast";
+import { Card } from "../../utils";
+import {
+  NanoDiagnostics,
+  type NanoDiagnosticsResult,
+  type NanoFeatureDiagnostic,
+} from "../../plugins/NanoDiagnosticsPlugin";
+import { logger } from "../../utils/logger";
+
+const statusClasses: Record<string, string> = {
+  AVAILABLE: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300",
+  DOWNLOADABLE: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
+  DOWNLOADING: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
+  UNAVAILABLE: "bg-zinc-100 text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300",
+  ERROR: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300",
+};
+
+const StatusBadge = ({ feature }: { feature?: NanoFeatureDiagnostic }) => {
+  const status = feature?.status ?? "UNKNOWN";
+  const classes = statusClasses[status] ?? "bg-zinc-100 text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300";
+
+  return (
+    <span className={`rounded-full px-2.5 py-1 text-xs font-bold ${classes}`}>
+      {status}
+    </span>
+  );
+};
+
+const FeatureRow = ({
+  label,
+  feature,
+}: {
+  label: string;
+  feature?: NanoFeatureDiagnostic;
+}) => (
+  <div className="rounded-lg border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-900/40 p-3">
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-sm font-semibold text-zinc-700 dark:text-zinc-200">
+        {label}
+      </span>
+      <StatusBadge feature={feature} />
+    </div>
+    {feature?.error && (
+      <p className="mt-2 break-words text-xs leading-relaxed text-red-600 dark:text-red-300">
+        {feature.error}
+      </p>
+    )}
+  </div>
+);
+
+const NanoDiagnosticsSettings: React.FC = () => {
+  const [status, setStatus] = useState<NanoDiagnosticsResult | null>(null);
+  const [smokeResult, setSmokeResult] = useState<string | null>(null);
+  const [isBusy, setIsBusy] = useState(false);
+
+  const loadStatus = async () => {
+    if (!Capacitor.isNativePlatform()) {
+      toast("Nano Diagnose ist nur in der Android-App verfügbar.");
+      return;
+    }
+
+    setIsBusy(true);
+    setSmokeResult(null);
+    try {
+      const next = await NanoDiagnostics.getStatus();
+      setStatus(next);
+    } catch (err) {
+      logger.error("[NanoDiagnosticsSettings] Statusprüfung fehlgeschlagen:", err);
+      toast.error("Nano Status konnte nicht geprüft werden.");
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const downloadPrompt = async () => {
+    setIsBusy(true);
+    try {
+      await NanoDiagnostics.downloadPrompt();
+      toast.success("Prompt-Modell bereit.");
+      await loadStatus();
+    } catch (err) {
+      logger.error("[NanoDiagnosticsSettings] Prompt-Download fehlgeschlagen:", err);
+      toast.error("Prompt-Download fehlgeschlagen.");
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const runSmokeTest = async () => {
+    setIsBusy(true);
+    setSmokeResult(null);
+    try {
+      const result = await NanoDiagnostics.runPromptSmokeTest();
+      setSmokeResult(result.text);
+    } catch (err) {
+      logger.error("[NanoDiagnosticsSettings] Prompt-Test fehlgeschlagen:", err);
+      toast.error("Prompt-Test fehlgeschlagen.");
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  return (
+    <Card className="p-5 space-y-4 border-violet-200 dark:border-violet-900 bg-violet-50/60 dark:bg-violet-950/20">
+      <div className="flex items-start gap-3">
+        <div className="rounded-lg bg-violet-100 p-2 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300">
+          <BrainCircuit size={20} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h3 className="font-bold text-zinc-800 dark:text-white">Gemini Nano Diagnose</h3>
+          <p className="mt-1 text-sm leading-relaxed text-zinc-600 dark:text-zinc-300">
+            Prüft AICore, Speech Advanced und Prompt API direkt auf diesem Android-Gerät.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-2">
+        <button
+          type="button"
+          onClick={loadStatus}
+          disabled={isBusy}
+          className="flex w-full items-center justify-center gap-2 rounded-xl bg-violet-600 px-4 py-3 text-sm font-bold text-white transition-colors hover:bg-violet-700 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          <RefreshCw size={17} className={isBusy ? "animate-spin" : ""} />
+          Status prüfen
+        </button>
+
+        <div className="grid grid-cols-2 gap-2">
+          <button
+            type="button"
+            onClick={downloadPrompt}
+            disabled={isBusy || status?.prompt.status !== "DOWNLOADABLE"}
+            className="flex items-center justify-center gap-2 rounded-xl border border-violet-200 bg-white px-3 py-2.5 text-xs font-bold text-violet-700 transition-colors hover:bg-violet-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-violet-900 dark:bg-zinc-800 dark:text-violet-300 dark:hover:bg-zinc-700"
+          >
+            <Download size={15} />
+            Prompt laden
+          </button>
+
+          <button
+            type="button"
+            onClick={runSmokeTest}
+            disabled={isBusy || status?.prompt.status !== "AVAILABLE"}
+            className="flex items-center justify-center gap-2 rounded-xl border border-violet-200 bg-white px-3 py-2.5 text-xs font-bold text-violet-700 transition-colors hover:bg-violet-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-violet-900 dark:bg-zinc-800 dark:text-violet-300 dark:hover:bg-zinc-700"
+          >
+            <Play size={15} />
+            Prompt testen
+          </button>
+        </div>
+      </div>
+
+      {status && (
+        <div className="space-y-2">
+          <div className="rounded-lg bg-white/80 p-3 text-xs text-zinc-600 dark:bg-zinc-900/40 dark:text-zinc-300">
+            <div><b>Gerät:</b> {status.device ?? "unbekannt"}</div>
+            <div><b>Android SDK:</b> {status.androidSdk ?? "unbekannt"}</div>
+            <div><b>AICore:</b> {status.aicoreVersion ?? "nicht gefunden"}</div>
+          </div>
+          <FeatureRow label="Speech Advanced de-DE" feature={status.speechAdvanced} />
+          <FeatureRow label="Prompt API" feature={status.prompt} />
+        </div>
+      )}
+
+      {smokeResult && (
+        <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-sm font-semibold text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950/30 dark:text-emerald-300">
+          {smokeResult}
+        </div>
+      )}
+    </Card>
+  );
+};
+
+export default NanoDiagnosticsSettings;

--- a/src/components/Settings/NanoDiagnosticsSettings.tsx
+++ b/src/components/Settings/NanoDiagnosticsSettings.tsx
@@ -55,6 +55,10 @@ const NanoDiagnosticsSettings: React.FC = () => {
   const [status, setStatus] = useState<NanoDiagnosticsResult | null>(null);
   const [smokeResult, setSmokeResult] = useState<string | null>(null);
   const [isBusy, setIsBusy] = useState(false);
+  const speechStatus = status?.speechAdvanced.status;
+  const promptStatus = status?.prompt.status;
+  const speechDownloadLabel = speechStatus === "AVAILABLE" ? "Speech bereit" : "Speech laden";
+  const promptDownloadLabel = promptStatus === "AVAILABLE" ? "Prompt bereit" : "Prompt laden";
 
   const loadStatus = async () => {
     if (!Capacitor.isNativePlatform()) {
@@ -84,6 +88,21 @@ const NanoDiagnosticsSettings: React.FC = () => {
     } catch (err) {
       logger.error("[NanoDiagnosticsSettings] Prompt-Download fehlgeschlagen:", err);
       toast.error("Prompt-Download fehlgeschlagen.");
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const downloadSpeechAdvanced = async () => {
+    setIsBusy(true);
+    setSmokeResult(null);
+    try {
+      await NanoDiagnostics.downloadSpeechAdvanced();
+      toast.success("Speech de-DE bereit.");
+      await loadStatus();
+    } catch (err) {
+      logger.error("[NanoDiagnosticsSettings] Speech-Download fehlgeschlagen:", err);
+      toast.error("Speech-Download fehlgeschlagen.");
     } finally {
       setIsBusy(false);
     }
@@ -131,19 +150,29 @@ const NanoDiagnosticsSettings: React.FC = () => {
         <div className="grid grid-cols-2 gap-2">
           <button
             type="button"
-            onClick={downloadPrompt}
-            disabled={isBusy || status?.prompt.status !== "DOWNLOADABLE"}
+            onClick={downloadSpeechAdvanced}
+            disabled={isBusy || speechStatus !== "DOWNLOADABLE"}
             className="flex items-center justify-center gap-2 rounded-xl border border-violet-200 bg-white px-3 py-2.5 text-xs font-bold text-violet-700 transition-colors hover:bg-violet-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-violet-900 dark:bg-zinc-800 dark:text-violet-300 dark:hover:bg-zinc-700"
           >
             <Download size={15} />
-            Prompt laden
+            {speechDownloadLabel}
+          </button>
+
+          <button
+            type="button"
+            onClick={downloadPrompt}
+            disabled={isBusy || promptStatus !== "DOWNLOADABLE"}
+            className="flex items-center justify-center gap-2 rounded-xl border border-violet-200 bg-white px-3 py-2.5 text-xs font-bold text-violet-700 transition-colors hover:bg-violet-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-violet-900 dark:bg-zinc-800 dark:text-violet-300 dark:hover:bg-zinc-700"
+          >
+            <Download size={15} />
+            {promptDownloadLabel}
           </button>
 
           <button
             type="button"
             onClick={runSmokeTest}
-            disabled={isBusy || status?.prompt.status !== "AVAILABLE"}
-            className="flex items-center justify-center gap-2 rounded-xl border border-violet-200 bg-white px-3 py-2.5 text-xs font-bold text-violet-700 transition-colors hover:bg-violet-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-violet-900 dark:bg-zinc-800 dark:text-violet-300 dark:hover:bg-zinc-700"
+            disabled={isBusy || promptStatus !== "AVAILABLE"}
+            className="col-span-2 flex items-center justify-center gap-2 rounded-xl border border-violet-200 bg-white px-3 py-2.5 text-xs font-bold text-violet-700 transition-colors hover:bg-violet-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-violet-900 dark:bg-zinc-800 dark:text-violet-300 dark:hover:bg-zinc-700"
           >
             <Play size={15} />
             Prompt testen

--- a/src/components/__tests__/EntryForm.test.tsx
+++ b/src/components/__tests__/EntryForm.test.tsx
@@ -1,9 +1,20 @@
 import React from "react";
 import type { SyntheticEvent } from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, fireEvent, cleanup } from "@testing-library/react";
+import { render, fireEvent, cleanup, waitFor } from "@testing-library/react";
 
 // ─── Mocks (VOR dem EntryForm-Import) ───────────────────────
+
+const isNativePlatform = vi.hoisted(() => vi.fn(() => false));
+const nanoDiagnosticsMock = vi.hoisted(() => ({
+  recognizeSpeech: vi.fn(),
+  parseEntrySpeech: vi.fn(),
+}));
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: { isNativePlatform },
+  registerPlugin: vi.fn(() => ({})),
+}));
 
 vi.mock("@capacitor/haptics", () => ({
   Haptics: { impact: vi.fn().mockResolvedValue(undefined) },
@@ -75,6 +86,10 @@ vi.mock("../../plugins/Material3DatePickerPlugin", () => ({
   Material3DatePicker: {
     pickDate: vi.fn(),
   },
+}));
+
+vi.mock("../../plugins/NanoDiagnosticsPlugin", () => ({
+  NanoDiagnostics: nanoDiagnosticsMock,
 }));
 
 // useWorkCodes: minimal-Mock mit einem Code
@@ -182,6 +197,7 @@ const renderForm = (opts: RenderOptions = {}) => {
 describe("EntryForm", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    isNativePlatform.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -324,5 +340,40 @@ describe("EntryForm", () => {
 
     expect(await findByText("Native Datumsauswahl nicht verfügbar – bitte Datum manuell wählen.")).toBeTruthy();
     expect(container.querySelector('input[type="date"]')).toBeTruthy();
+  });
+
+  it("füllt einen Eintrag aus Spracheingabe per Nano-Vorschlag", async () => {
+    isNativePlatform.mockReturnValue(true);
+    nanoDiagnosticsMock.recognizeSpeech.mockResolvedValueOnce({
+      text: "Heute sechs bis sechzehn dreißig Kogler Wartung halbe Stunde Pause",
+    });
+    nanoDiagnosticsMock.parseEntrySpeech.mockResolvedValueOnce({
+      type: "work",
+      date: "2026-04-07",
+      start: "06:00",
+      end: "16:30",
+      pause: 30,
+      project: "Kogler Wartung",
+      codeId: 1,
+      confidence: "high",
+    });
+
+    const { findByLabelText, setStartTime, setEndTime, setPauseDuration, setProject, setCode } = renderForm();
+    fireEvent.click(await findByLabelText("Eintrag per Sprache ausfüllen"));
+
+    expect(nanoDiagnosticsMock.recognizeSpeech).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(nanoDiagnosticsMock.parseEntrySpeech).toHaveBeenCalledWith({
+        text: "Heute sechs bis sechzehn dreißig Kogler Wartung halbe Stunde Pause",
+        date: "2026-04-07",
+        workCodes: [],
+        existingProjects: [],
+      });
+    });
+    expect(setStartTime).toHaveBeenCalledWith("06:00");
+    expect(setEndTime).toHaveBeenCalledWith("16:30");
+    expect(setPauseDuration).toHaveBeenCalledWith(30);
+    expect(setProject).toHaveBeenCalledWith("Kogler Wartung");
+    expect(setCode).toHaveBeenCalledWith(1);
   });
 });

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -99,7 +99,15 @@
     "distanceOrNote": "Strecke / Notiz",
     "project": "Projekt",
     "projectPlaceholder": "...",
-    "knownProjects": "Bekannte Projekte"
+    "knownProjects": "Bekannte Projekte",
+    "speech": {
+      "projectButton": "Spracheingabe",
+      "listening": "Ich höre zu...",
+      "inserted": "Spracheingabe übernommen.",
+      "empty": "Keine Sprache erkannt.",
+      "failed": "Spracheingabe fehlgeschlagen.",
+      "nativeOnly": "Spracheingabe ist nur in der Android-App verfügbar."
+    }
   },
   "reports": {
     "title": "Stundenzettel",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -101,10 +101,14 @@
     "projectPlaceholder": "...",
     "knownProjects": "Bekannte Projekte",
     "speech": {
+      "entryButton": "Eintrag per Sprache ausfüllen",
+      "entryButtonShort": "Diktieren",
       "projectButton": "Spracheingabe",
       "listening": "Ich höre zu...",
+      "entryInserted": "Spracheintrag übernommen. Bitte kurz prüfen.",
       "inserted": "Spracheingabe übernommen.",
       "empty": "Keine Sprache erkannt.",
+      "entryFailed": "Spracheintrag konnte nicht ausgewertet werden.",
       "failed": "Spracheingabe fehlgeschlagen.",
       "nativeOnly": "Spracheingabe ist nur in der Android-App verfügbar."
     }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -101,10 +101,14 @@
     "projectPlaceholder": "…",
     "knownProjects": "Known projects",
     "speech": {
+      "entryButton": "Fill entry by voice",
+      "entryButtonShort": "Dictate",
       "projectButton": "Voice input",
       "listening": "Listening...",
+      "entryInserted": "Voice entry inserted. Please review it.",
       "inserted": "Voice input inserted.",
       "empty": "No speech recognized.",
+      "entryFailed": "Voice entry could not be parsed.",
       "failed": "Voice input failed.",
       "nativeOnly": "Voice input is only available in the Android app."
     }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -99,7 +99,15 @@
     "distanceOrNote": "Route / Note",
     "project": "Project",
     "projectPlaceholder": "…",
-    "knownProjects": "Known projects"
+    "knownProjects": "Known projects",
+    "speech": {
+      "projectButton": "Voice input",
+      "listening": "Listening...",
+      "inserted": "Voice input inserted.",
+      "empty": "No speech recognized.",
+      "failed": "Voice input failed.",
+      "nativeOnly": "Voice input is only available in the Android app."
+    }
   },
   "reports": {
     "title": "Timesheet",

--- a/src/plugins/NanoDiagnosticsPlugin.ts
+++ b/src/plugins/NanoDiagnosticsPlugin.ts
@@ -25,12 +25,33 @@ export interface NanoSpeechRecognitionResult {
   text: string;
 }
 
+export interface NanoEntrySpeechParseRequest {
+  text: string;
+  date: string;
+  workCodes: Array<{ id: number; label: string }>;
+  existingProjects?: string[];
+}
+
+export interface NanoEntrySpeechParseResult {
+  type?: "work" | "drive" | "vacation" | "sick" | "time_comp";
+  date?: string;
+  start?: string;
+  end?: string;
+  pause?: number;
+  project?: string;
+  codeId?: number;
+  specialManualMode?: boolean;
+  confidence?: "high" | "medium" | "low";
+  rawText?: string;
+}
+
 export interface NanoDiagnosticsPlugin {
   getStatus(): Promise<NanoDiagnosticsResult>;
   downloadSpeechAdvanced(): Promise<void>;
   downloadPrompt(): Promise<void>;
   runPromptSmokeTest(): Promise<NanoPromptSmokeTestResult>;
   recognizeSpeech(): Promise<NanoSpeechRecognitionResult>;
+  parseEntrySpeech(options: NanoEntrySpeechParseRequest): Promise<NanoEntrySpeechParseResult>;
 }
 
 export const NanoDiagnostics =

--- a/src/plugins/NanoDiagnosticsPlugin.ts
+++ b/src/plugins/NanoDiagnosticsPlugin.ts
@@ -1,0 +1,36 @@
+import { registerPlugin } from "@capacitor/core";
+
+export type NanoFeatureStatus =
+  | "AVAILABLE"
+  | "DOWNLOADABLE"
+  | "DOWNLOADING"
+  | "UNAVAILABLE"
+  | "ERROR"
+  | string;
+
+export interface NanoFeatureDiagnostic {
+  status: NanoFeatureStatus;
+  error?: string;
+}
+
+export interface NanoDiagnosticsResult {
+  androidSdk?: number;
+  device?: string;
+  aicoreInstalled: boolean;
+  aicoreVersion?: string | null;
+  speechAdvanced: NanoFeatureDiagnostic;
+  prompt: NanoFeatureDiagnostic;
+}
+
+export interface NanoPromptSmokeTestResult {
+  text: string;
+}
+
+export interface NanoDiagnosticsPlugin {
+  getStatus(): Promise<NanoDiagnosticsResult>;
+  downloadPrompt(): Promise<void>;
+  runPromptSmokeTest(): Promise<NanoPromptSmokeTestResult>;
+}
+
+export const NanoDiagnostics =
+  registerPlugin<NanoDiagnosticsPlugin>("NanoDiagnostics");

--- a/src/plugins/NanoDiagnosticsPlugin.ts
+++ b/src/plugins/NanoDiagnosticsPlugin.ts
@@ -28,6 +28,7 @@ export interface NanoPromptSmokeTestResult {
 
 export interface NanoDiagnosticsPlugin {
   getStatus(): Promise<NanoDiagnosticsResult>;
+  downloadSpeechAdvanced(): Promise<void>;
   downloadPrompt(): Promise<void>;
   runPromptSmokeTest(): Promise<NanoPromptSmokeTestResult>;
 }

--- a/src/plugins/NanoDiagnosticsPlugin.ts
+++ b/src/plugins/NanoDiagnosticsPlugin.ts
@@ -26,11 +26,16 @@ export interface NanoPromptSmokeTestResult {
   text: string;
 }
 
+export interface NanoSpeechRecognitionResult {
+  text: string;
+}
+
 export interface NanoDiagnosticsPlugin {
   getStatus(): Promise<NanoDiagnosticsResult>;
   downloadSpeechAdvanced(): Promise<void>;
   downloadPrompt(): Promise<void>;
   runPromptSmokeTest(): Promise<NanoPromptSmokeTestResult>;
+  recognizeSpeech(): Promise<NanoSpeechRecognitionResult>;
 }
 
 export const NanoDiagnostics =

--- a/src/plugins/NanoDiagnosticsPlugin.ts
+++ b/src/plugins/NanoDiagnosticsPlugin.ts
@@ -14,12 +14,7 @@ export interface NanoFeatureDiagnostic {
 }
 
 export interface NanoDiagnosticsResult {
-  androidSdk?: number;
-  device?: string;
-  aicoreInstalled: boolean;
-  aicoreVersion?: string | null;
   speechAdvanced: NanoFeatureDiagnostic;
-  prompt: NanoFeatureDiagnostic;
 }
 
 export interface NanoPromptSmokeTestResult {

--- a/src/plugins/__tests__/nativePlugins.test.ts
+++ b/src/plugins/__tests__/nativePlugins.test.ts
@@ -20,4 +20,11 @@ describe("native plugin wrappers", () => {
     expect(registerPlugin).toHaveBeenCalledWith("SystemBars");
     expect(SystemBars).toEqual({ name: "SystemBars" });
   });
+
+  it("registers the Android nano diagnostics plugin", async () => {
+    const { NanoDiagnostics } = await import("../NanoDiagnosticsPlugin");
+
+    expect(registerPlugin).toHaveBeenCalledWith("NanoDiagnostics");
+    expect(NanoDiagnostics).toEqual({ name: "NanoDiagnostics" });
+  });
 });


### PR DESCRIPTION
## Summary

Adds a first Gemini Nano diagnostics spike behind Expert Mode/Hausmasta mode.

- adds a native Android Capacitor plugin for AICore, ML Kit GenAI Speech Recognition, and Prompt API status checks
- adds a Settings diagnostics card for checking Speech Advanced, Prompt API, AICore version, prompt download, and a smoke test
- wires ML Kit GenAI dependencies and RECORD_AUDIO permission for the upcoming speech test path

## Validation

- `npm run typecheck`
- `npm run test -- src/plugins/__tests__/nativePlugins.test.ts`
- `npm run lint -- src/components/Settings/NanoDiagnosticsSettings.tsx src/plugins/NanoDiagnosticsPlugin.ts src/plugins/__tests__/nativePlugins.test.ts`
- `npm run build`

Android/Kotlin compilation was not run locally because this runtime has no Java/JDK in PATH.