### PR TITLE
docs: clarify local data protection

### DIFF
--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -161,7 +161,7 @@
         </ul>
 
         <h2>7. Datensicherheit</h2>
-        <p>Deine Daten werden in einer verschl&uuml;sselten SQLite-Datenbank im lokalen Speicher deines Android-Ger&auml;ts abgelegt. Nextcloud-Zugangsdaten werden zus&auml;tzlich mit AES-GCM verschl&uuml;sselt. Die Sicherheit deiner Daten h&auml;ngt auch von den Sicherheitseinstellungen deines Ger&auml;ts ab (Bildschirmsperre, Verschl&uuml;sselung, etc.).</p>
+        <p>Deine Daten werden in einer SQLite-Datenbank im privaten Speicherbereich der App auf deinem Android-Ger&auml;t abgelegt. Die Android-App-Sandbox verhindert den Zugriff durch andere regul&auml;re Apps. Abh&auml;ngig von deinem Ger&auml;t und dessen Einstellungen werden die gespeicherten Daten zus&auml;tzlich durch die systemseitige Android-Ger&auml;teverschl&uuml;sselung gesch&uuml;tzt. Die SQLite-Datenbank selbst verwendet keine separate anwendungsseitige Verschl&uuml;sselung. Nextcloud-Zugangsdaten werden zus&auml;tzlich mit AES-GCM verschl&uuml;sselt. Die Sicherheit deiner Daten h&auml;ngt auch von den Sicherheitseinstellungen deines Ger&auml;ts ab (Bildschirmsperre, Ger&auml;teverschl&uuml;sselung etc.).</p>
 
         <h2>8. Deine Rechte</h2>
         <p>Da alle Daten lokal auf deinem Ger&auml;t gespeichert werden, hast du die volle Kontrolle:</p>
@@ -180,7 +180,7 @@
             <strong>E-Mail:</strong> <a href="mailto:project@kainer.co.at">project@kainer.co.at</a>
         </div>
 
-        <p class="date">Stand: April 2026</p>
+        <p class="date">Stand: Juli 2026</p>
     </div>
 </body>
 </html>


### PR DESCRIPTION
## Zusammenfassung

- beschreibt die lokale SQLite-Speicherung technisch korrekt
- erklärt Android-App-Sandbox und systemseitige Geräteverschlüsselung
- stellt klar, dass die SQLite-Datenbank keine separate App-Verschlüsselung verwendet
- aktualisiert den Stand der Datenschutzerklärung auf Juli 2026

## Prüfung

- `git diff --check`
