### PR TITLE
fix: delete entries and attachments atomically

### DIFF
--- a/src/db/repositories/__tests__/entriesRepo.test.ts
+++ b/src/db/repositories/__tests__/entriesRepo.test.ts
@@ -145,22 +145,30 @@ describe("updateEntryInDb", () => {
 });
 
 describe("deleteEntryFromDb / deleteAllEntriesFromDb", () => {
-  it("schickt DELETE mit Parameter", async () => {
-    runMock.mockResolvedValue(undefined);
+  it("löscht Attachment-Metadaten und Entry gemeinsam in einer Transaktion", async () => {
+    executeSetMock.mockResolvedValue(undefined);
     await deleteEntryFromDb(7);
-    expect(runMock).toHaveBeenCalledWith(expect.stringMatching(/DELETE FROM entries/i), [7]);
+    expect(executeSetMock).toHaveBeenCalledWith([
+      { statement: expect.stringMatching(/DELETE FROM attachments/i), values: [7] },
+      { statement: expect.stringMatching(/DELETE FROM entries/i), values: [7] },
+    ]);
   });
 
   it("übergibt Legacy-String-IDs unverändert an DELETE", async () => {
-    runMock.mockResolvedValue(undefined);
+    executeSetMock.mockResolvedValue(undefined);
     await deleteEntryFromDb("legacy-7");
-    expect(runMock).toHaveBeenCalledWith(expect.stringMatching(/DELETE FROM entries/i), ["legacy-7"]);
+    const [set] = executeSetMock.mock.calls[0];
+    expect(set[0].values).toEqual(["legacy-7"]);
+    expect(set[1].values).toEqual(["legacy-7"]);
   });
 
-  it("schickt bulk DELETE ohne Parameter", async () => {
-    executeMock.mockResolvedValue(undefined);
+  it("löscht alle Attachment-Metadaten und Entries gemeinsam", async () => {
+    executeSetMock.mockResolvedValue(undefined);
     await deleteAllEntriesFromDb();
-    expect(executeMock).toHaveBeenCalledWith("DELETE FROM entries;");
+    expect(executeSetMock).toHaveBeenCalledWith([
+      { statement: "DELETE FROM attachments;", values: [] },
+      { statement: "DELETE FROM entries;", values: [] },
+    ]);
   });
 });
 

--- a/src/db/repositories/entriesRepo.ts
+++ b/src/db/repositories/entriesRepo.ts
@@ -91,7 +91,10 @@ export async function updateEntryInDb(entry: Entry): Promise<void> {
  * @returns {Promise<void>}
  */
 export async function deleteEntryFromDb(id: number | string): Promise<void> {
-  await run("DELETE FROM entries WHERE id = ?", [id]);
+  await executeSet([
+    { statement: "DELETE FROM attachments WHERE entryId = ?", values: [id] },
+    { statement: "DELETE FROM entries WHERE id = ?", values: [id] },
+  ]);
 }
 
 /**
@@ -99,7 +102,10 @@ export async function deleteEntryFromDb(id: number | string): Promise<void> {
  * @returns {Promise<void>}
  */
 export async function deleteAllEntriesFromDb(): Promise<void> {
-  await execute("DELETE FROM entries;");
+  await executeSet([
+    { statement: "DELETE FROM attachments;", values: [] },
+    { statement: "DELETE FROM entries;", values: [] },
+  ]);
 }
 
 /**

--- a/src/hooks/__tests__/useAttachments.test.ts
+++ b/src/hooks/__tests__/useAttachments.test.ts
@@ -1,0 +1,97 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Attachment } from "../../types";
+
+const deleteFileMock = vi.fn();
+const getAllAttachmentsMock = vi.fn();
+const deleteAttachmentFromDbMock = vi.fn();
+
+vi.mock("@capacitor/filesystem", () => ({
+  Directory: { Data: "DATA" },
+  Filesystem: {
+    deleteFile: (...args: unknown[]) => deleteFileMock(...args),
+  },
+}));
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: { isNativePlatform: () => true },
+}));
+
+vi.mock("../../db/storageMode", () => ({
+  isSQLiteActive: () => true,
+}));
+
+vi.mock("../../db/repositories/attachmentsRepo", () => ({
+  getAllAttachments: (...args: unknown[]) => getAllAttachmentsMock(...args),
+  getAllLabelSuggestions: vi.fn().mockResolvedValue([]),
+  insertAttachment: vi.fn(),
+  deleteAttachmentFromDb: (...args: unknown[]) => deleteAttachmentFromDbMock(...args),
+  pushLabelSuggestion: vi.fn(),
+}));
+
+vi.mock("../../utils/logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+import { useAttachments } from "../useAttachments";
+
+const attachments: Attachment[] = [
+  {
+    id: "att-1",
+    entryId: 7,
+    label: "Beleg",
+    fileName: "beleg.pdf",
+    mimeType: "application/pdf",
+    storagePath: "attachments/att-1.pdf",
+    fileSize: 100,
+    createdAt: "2026-07-11T10:00:00.000Z",
+  },
+  {
+    id: "att-2",
+    entryId: 8,
+    label: "Foto",
+    fileName: "foto.jpg",
+    mimeType: "image/jpeg",
+    storagePath: "attachments/att-2.jpg",
+    fileSize: 200,
+    createdAt: "2026-07-11T11:00:00.000Z",
+  },
+];
+
+describe("useAttachments.removeAttachmentsForEntry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getAllAttachmentsMock.mockResolvedValue(attachments);
+    deleteFileMock.mockResolvedValue(undefined);
+  });
+
+  it("bereinigt nach dem DB-Commit nur State und Dateien", async () => {
+    const { result } = renderHook(() => useAttachments());
+
+    await vi.waitFor(() => expect(result.current.attachments).toHaveLength(2));
+
+    await act(async () => {
+      await result.current.removeAttachmentsForEntry(7);
+    });
+
+    expect(result.current.attachments.map((item) => item.id)).toEqual(["att-2"]);
+    expect(deleteFileMock).toHaveBeenCalledWith({
+      path: "attachments/att-1.pdf",
+      directory: "DATA",
+    });
+    expect(deleteAttachmentFromDbMock).not.toHaveBeenCalled();
+  });
+
+  it("lässt eine fehlgeschlagene Dateibereinigung den erfolgreichen Delete nicht kippen", async () => {
+    deleteFileMock.mockRejectedValueOnce(new Error("file missing"));
+    const { result } = renderHook(() => useAttachments());
+
+    await vi.waitFor(() => expect(result.current.attachments).toHaveLength(2));
+
+    await expect(act(async () => {
+      await result.current.removeAttachmentsForEntry(7);
+    })).resolves.toBeUndefined();
+
+    expect(result.current.attachments.map((item) => item.id)).toEqual(["att-2"]);
+  });
+});

--- a/src/hooks/__tests__/useEntries.test.ts
+++ b/src/hooks/__tests__/useEntries.test.ts
@@ -222,6 +222,24 @@ describe("useEntries", () => {
     expect(mockDeleteAllEntriesFromDb).toHaveBeenCalledOnce();
   });
 
+  it("deleteAllEntries stellt den State bei Transaktionsfehler wieder her", async () => {
+    mockGetAllEntries.mockResolvedValue([makeEntry({ id: 1 }), makeEntry({ id: 2 })]);
+    const { result } = renderHook(() => useEntries());
+
+    await vi.waitFor(() => {
+      expect(result.current.entries).toHaveLength(2);
+    });
+
+    mockDeleteAllEntriesFromDb.mockRejectedValueOnce(new Error("delete all failed"));
+
+    await expect(act(async () => {
+      await result.current.deleteAllEntries();
+    })).rejects.toThrow("delete all failed");
+
+    expect(result.current.entries).toHaveLength(2);
+    expect(toast.error).toHaveBeenCalledWith(expect.stringContaining("gelöscht"));
+  });
+
   it("importEntries replaces all entries and bulk-inserts into SQLite", async () => {
     const { result } = renderHook(() => useEntries());
 

--- a/src/hooks/actions/__tests__/actions.test.tsx
+++ b/src/hooks/actions/__tests__/actions.test.tsx
@@ -403,7 +403,22 @@ describe("useDeleteActions", () => {
 
     expect(removeAttachmentsForEntry).toHaveBeenCalledWith(7);
     expect(deleteEntry).toHaveBeenCalledWith(7);
+    expect(deleteEntry.mock.invocationCallOrder[0]).toBeLessThan(
+      removeAttachmentsForEntry.mock.invocationCallOrder[0]
+    );
     expect(setDeleteTarget).toHaveBeenCalledWith(null);
+  });
+
+  it("bereinigt Attachments nicht, wenn das atomare Entry-Delete fehlschlägt", async () => {
+    const deleteEntry = vi.fn().mockRejectedValue(new Error("db failed"));
+    const removeAttachmentsForEntry = vi.fn();
+    const { result } = mount({ deleteEntry, removeAttachmentsForEntry });
+
+    await expect(act(async () => {
+      await result.current.executeDelete({ type: "single", id: 7 });
+    })).rejects.toThrow("db failed");
+
+    expect(removeAttachmentsForEntry).not.toHaveBeenCalled();
   });
 
   it("type='all' schreibt Sicherheits-Backup und setzt User zurück", async () => {

--- a/src/hooks/actions/useDeleteActions.ts
+++ b/src/hooks/actions/useDeleteActions.ts
@@ -36,6 +36,8 @@ export function useDeleteActions({
     async (deleteTarget: DeleteTarget | null) => {
       if (deleteTarget?.type === "single") {
         if (deleteTarget.id === undefined) return;
+        // Löscht Entry + Attachment-Metadaten atomar in SQLite. Erst nach
+        // erfolgreichem Commit werden State und Dateien bereinigt.
         await deleteEntry(deleteTarget.id);
         if (removeAttachmentsForEntry) {
           await removeAttachmentsForEntry(deleteTarget.id);
@@ -60,12 +62,13 @@ export function useDeleteActions({
           /* Best-effort, nicht blockierend */
         }
 
+        // Löscht alle Entries + Attachment-Metadaten atomar in SQLite.
+        await deleteAllEntries();
         if (entries?.length && removeAttachmentsForEntry) {
           for (const entry of entries) {
             await removeAttachmentsForEntry(entry.id);
           }
         }
-        await deleteAllEntries();
         const emptyUser = {
           name: "",
           position: "",

--- a/src/hooks/useAttachments.ts
+++ b/src/hooks/useAttachments.ts
@@ -88,8 +88,8 @@ const fileToBase64 = (file: File): Promise<string> =>
  * - `attachmentStats` — `{ total, labels }` (memoisiert)
  * - `addAttachment(entryId, label, file)` — legt neuen Anhang an
  * - `removeAttachment(attachmentId)` — löscht einen Anhang (inkl. Datei)
- * - `removeAttachmentsForEntry(entryId)` — löscht alle Anhänge zu einem
- *   Eintrag (wird beim Entry-Delete automatisch gerufen)
+ * - `removeAttachmentsForEntry(entryId)` — bereinigt nach dem atomaren
+ *   Entry-Delete den State und die Dateien aller zugehörigen Anhänge
  * - `getAttachmentsForEntry(entryId)` — Anhänge eines Eintrags
  * - `getAttachmentsForEntries(entryIds)` — Bulk-Version
  * - `getLabelSuggestions()` — aktuelle MRU-Labels
@@ -251,11 +251,26 @@ export function useAttachments() {
 
   const removeAttachmentsForEntry = useCallback(async (entryId: number | string) => {
     const matching = attachments.filter((item) => item.entryId === entryId);
+    if (matching.length === 0) return;
+
+    // Die Metadaten wurden zusammen mit dem Entry bereits atomar in SQLite
+    // gelöscht. Danach nur noch State und Dateien best-effort bereinigen.
+    setAttachments((prev) => prev.filter((item) => item.entryId !== entryId));
 
     for (const item of matching) {
-      await removeAttachment(item.id);
+      if (!item.storagePath) continue;
+      try {
+        ensureNative();
+        await Filesystem.deleteFile({
+          path: item.storagePath,
+          directory: Directory.Data,
+        });
+      } catch {
+        // Metadaten sind bereits entfernt; eine fehlende/verwaiste Datei darf
+        // den erfolgreich abgeschlossenen Entry-Delete nicht zurückrollen.
+      }
     }
-  }, [attachments, removeAttachment]);
+  }, [attachments]);
 
   // ─── Read Helpers (unverändert) ───────────────────────────
 

--- a/src/hooks/useEntries.ts
+++ b/src/hooks/useEntries.ts
@@ -141,6 +141,7 @@ export function useEntries() {
       logger.error("[useEntries] SQLite-Write fehlgeschlagen:", err);
       setEntries(backup);
       toast.error(t("toasts.entry.deleteAllFailed"));
+      throw err;
     }
   }, [t]);
 


### PR DESCRIPTION
## Zusammenfassung
- löscht Entry und Attachment-Metadaten gemeinsam in einer SQLite-Transaktion
- stellt UI-State bei Datenbankfehlern wieder her
- bereinigt Attachment-State und Dateien erst nach erfolgreichem Commit
- bricht Alles löschen bei Transaktionsfehlern korrekt ab

## Validierung
- 831 Tests bestanden
- Typecheck bestanden
- Produktions-Build bestanden
- ESLint ohne Fehler; 11 bestehende Warnungen
- git diff --check bestanden
- zusätzliche Fehlerfall-Tests ergänzt